### PR TITLE
Multi selection search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,205 +1,205 @@
 {
-	"name": "vscode-modaledit",
-	"displayName": "ModalEdit",
-	"description": "DIY Vim emulation",
-	"version": "1.7.0",
-	"publisher": "johtela",
-	"engines": {
-		"vscode": "^1.43.0"
-	},
-	"repository": {
-		"url": "https://github.com/johtela/vscode-modaledit"
-	},
-	"license": "MPL-2.0",
-	"categories": [
-		"Keymaps",
-		"Other"
-	],
-	"homepage": "https://johtela.github.io/vscode-modaledit",
-	"activationEvents": [
-		"*"
-	],
-	"icon": "images/normal.jpg",
-	"main": "./dist/extension.js",
-	"contributes": {
-		"configuration": {
-			"type": "object",
-			"title": "ModalEdit",
-			"properties": {
-				"modaledit.keybindings": {
-					"type": "object",
-					"description": "Keybindings map, key → VS Code actions/commands",
-					"default": {},
-					"patternProperties": {
-						"^.([\\-,].)*$": {
-							"anyOf": [
-								{
-									"type": "string",
-									"description": "VS Code command"
-								},
-								{
-									"type": "array",
-									"description": "Sequence of commands",
-									"items": {
-										"anyOf": [
-											{
-												"type": "object",
-												"description": "Action"
-											},
-											{
-												"type": "string",
-												"description": "VS Code command"
-											}
-										]
-									}
-								},
-								{
-									"type": "object",
-									"description": "VS Code command with arguments",
-									"properties": {
-										"command": {
-											"type": "string",
-											"description": "VS Code command"
-										},
-										"args": {
-											"description": "Command arguments",
-											"anyOf": [
-												{
-													"type": "object"
-												},
-												{
-													"type": "string"
-												}
-											]
-										}
-									}
-								},
-								{
-									"type": "object",
-									"description": "Conditional command",
-									"properties": {
-										"condition": {
-											"type": "string",
-											"description": "JavaScript expression that is evaluated"
-										}
-									}
-								},
-								{
-									"type": "number",
-									"description": "Keymap id"
-								}
-							]
-						}
-					}
-				},
-				"modaledit.insertCursorStyle": {
-					"type": "string",
-					"enum": [
-						"block",
-						"block-outline",
-						"line",
-						"line-thin",
-						"underline",
-						"underline-thin"
-					],
-					"default": "line",
-					"description": "Shape of the cursor when in insert mode."
-				},
-				"modaledit.normalCursorStyle": {
-					"type": "string",
-					"enum": [
-						"block",
-						"block-outline",
-						"line",
-						"line-thin",
-						"underline",
-						"underline-thin"
-					],
-					"default": "block",
-					"description": "Shape of the cursor when in normal mode."
-				},
-				"modaledit.searchCursorStyle": {
-					"type": "string",
-					"enum": [
-						"block",
-						"block-outline",
-						"line",
-						"line-thin",
-						"underline",
-						"underline-thin"
-					],
-					"default": "underline",
-					"description": "Shape of the cursor when incremental search is active."
-				},
-				"modaledit.startInNormalMode": {
-					"type": "boolean",
-					"default": true,
-					"description": "Is editor initially in normal mode?"
-				}
-			}
-		},
-		"commands": [
-			{
-				"command": "modaledit.toggle",
-				"title": "ModalEdit: Toggle normal / insert mode"
-			},
-			{
-				"command": "modaledit.enterNormal",
-				"title": "ModalEdit: Normal mode"
-			},
-			{
-				"command": "modaledit.enterInsert",
-				"title": "ModalEdit: Insert mode"
-			},
-			{
-				"command": "modaledit.defineBookmark",
-				"title": "ModalEdit: Define bookmark"
-			},
-			{
-				"command": "modaledit.goToBookmark",
-				"title": "ModalEdit: Go to bookmark"
-			},
-			{
-				"command": "modaledit.cancelSearch",
-				"title": "ModalEdit: Canel search mode"
-			},
-			{
-				"command": "modaledit.deleteCharFromSearch",
-				"title": "ModalEdit: Delete the last search character"
-			}
-		],
-		"keybindings": [
-			{
-				"key": "Escape",
-				"command": "modaledit.enterNormal",
-				"when": "editorTextFocus && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
-			},
-			{
-				"key": "Escape",
-				"command": "modaledit.cancelSearch",
-				"when": "editorTextFocus && modaledit.searching"
-			},
-			{
-				"key": "Backspace",
-				"command": "modaledit.deleteCharFromSearch",
-				"when": "editorTextFocus && modaledit.searching"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "webpack --mode production",
-		"webpack": "webpack --mode development",
-		"webpack-dev": "webpack --mode development --watch",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./"
-	},
-	"devDependencies": {
-		"@types/node": "^13.9.3",
-		"@types/vscode": "^1.43.0",
-		"ts-loader": "^6.2.2",
-		"typescript": "^3.8.3",
-		"webpack": "^4.42.0",
-		"webpack-cli": "^3.3.11"
-	},
-	"dependencies": {}
+    "name": "vscode-modaledit",
+    "displayName": "ModalEdit",
+    "description": "DIY Vim emulation",
+    "version": "1.7.0",
+    "publisher": "johtela",
+    "engines": {
+        "vscode": "^1.43.0"
+    },
+    "repository": {
+        "url": "https://github.com/johtela/vscode-modaledit"
+    },
+    "license": "MPL-2.0",
+    "categories": [
+        "Keymaps",
+        "Other"
+    ],
+    "homepage": "https://johtela.github.io/vscode-modaledit",
+    "activationEvents": [
+        "*"
+    ],
+    "icon": "images/normal.jpg",
+    "main": "./dist/extension.js",
+    "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "ModalEdit",
+            "properties": {
+                "modaledit.keybindings": {
+                    "type": "object",
+                    "description": "Keybindings map, key → VS Code actions/commands",
+                    "default": {},
+                    "patternProperties": {
+                        "^.([\\-,].)*$": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "description": "VS Code command"
+                                },
+                                {
+                                    "type": "array",
+                                    "description": "Sequence of commands",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "description": "Action"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "description": "VS Code command"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "description": "VS Code command with arguments",
+                                    "properties": {
+                                        "command": {
+                                            "type": "string",
+                                            "description": "VS Code command"
+                                        },
+                                        "args": {
+                                            "description": "Command arguments",
+                                            "anyOf": [
+                                                {
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "description": "Conditional command",
+                                    "properties": {
+                                        "condition": {
+                                            "type": "string",
+                                            "description": "JavaScript expression that is evaluated"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "number",
+                                    "description": "Keymap id"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "modaledit.insertCursorStyle": {
+                    "type": "string",
+                    "enum": [
+                        "block",
+                        "block-outline",
+                        "line",
+                        "line-thin",
+                        "underline",
+                        "underline-thin"
+                    ],
+                    "default": "line",
+                    "description": "Shape of the cursor when in insert mode."
+                },
+                "modaledit.normalCursorStyle": {
+                    "type": "string",
+                    "enum": [
+                        "block",
+                        "block-outline",
+                        "line",
+                        "line-thin",
+                        "underline",
+                        "underline-thin"
+                    ],
+                    "default": "block",
+                    "description": "Shape of the cursor when in normal mode."
+                },
+                "modaledit.searchCursorStyle": {
+                    "type": "string",
+                    "enum": [
+                        "block",
+                        "block-outline",
+                        "line",
+                        "line-thin",
+                        "underline",
+                        "underline-thin"
+                    ],
+                    "default": "underline",
+                    "description": "Shape of the cursor when incremental search is active."
+                },
+                "modaledit.startInNormalMode": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Is editor initially in normal mode?"
+                }
+            }
+        },
+        "commands": [
+            {
+                "command": "modaledit.toggle",
+                "title": "ModalEdit: Toggle normal / insert mode"
+            },
+            {
+                "command": "modaledit.enterNormal",
+                "title": "ModalEdit: Normal mode"
+            },
+            {
+                "command": "modaledit.enterInsert",
+                "title": "ModalEdit: Insert mode"
+            },
+            {
+                "command": "modaledit.defineBookmark",
+                "title": "ModalEdit: Define bookmark"
+            },
+            {
+                "command": "modaledit.goToBookmark",
+                "title": "ModalEdit: Go to bookmark"
+            },
+            {
+                "command": "modaledit.cancelSearch",
+                "title": "ModalEdit: Canel search mode"
+            },
+            {
+                "command": "modaledit.deleteCharFromSearch",
+                "title": "ModalEdit: Delete the last search character"
+            }
+        ],
+        "keybindings": [
+            {
+                "key": "Escape",
+                "command": "modaledit.enterNormal",
+                "when": "editorTextFocus && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
+            },
+            {
+                "key": "Escape",
+                "command": "modaledit.cancelSearch",
+                "when": "editorTextFocus && modaledit.searching"
+            },
+            {
+                "key": "Backspace",
+                "command": "modaledit.deleteCharFromSearch",
+                "when": "editorTextFocus && modaledit.searching"
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "webpack --mode production",
+        "webpack": "webpack --mode development",
+        "webpack-dev": "webpack --mode development --watch",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./"
+    },
+    "devDependencies": {
+        "@types/node": "^13.9.3",
+        "@types/vscode": "^1.43.0",
+        "ts-loader": "^6.2.2",
+        "typescript": "^3.8.3",
+        "webpack": "^4.42.0",
+        "webpack-cli": "^3.3.11"
+    },
+    "dependencies": {}
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
 /**
  * # Converting Keybinding Definitions to Actions
- * 
+ *
  * This module defines the schema of the configuration file using TypeScript
  * interfaces. We parse the configuration JSON to TypeScript objects which
  * directly define all the valid keyboard sequences and the commands that these
@@ -11,22 +11,22 @@ import * as vscode from 'vscode'
 //#endregion
 /**
  * ## Action Definitions
- * 
- * The keybinding configuration consist of _actions_ that can take three forms: 
- * an action can be a command (defined later), a keymap, or a number that refers 
+ *
+ * The keybinding configuration consist of _actions_ that can take three forms:
+ * an action can be a command (defined later), a keymap, or a number that refers
  * to a keymap defined earlier.
  */
 export type Action = Command | Keymap | number
 /**
- * Commands can be invoked in four ways: by specifying just command a name 
+ * Commands can be invoked in four ways: by specifying just command a name
  * (string), or using a conditional command, a command with parameters, or a
- * sequence (array) of commands. The definition is recursive, meaning that a 
+ * sequence (array) of commands. The definition is recursive, meaning that a
  * sequence can contain all four types of commands.
  */
 export type Command = string | Conditional | Parameterized | Command[]
 /**
- * A conditional command consist of condition (a JavaScript expression) and set 
- * of branches to take depending on the result of the condition. Each branch can 
+ * A conditional command consist of condition (a JavaScript expression) and set
+ * of branches to take depending on the result of the condition. Each branch can
  * be any type of command defined above.
  */
 export interface Conditional {
@@ -36,10 +36,10 @@ export interface Conditional {
 /**
  * A command that takes arguments can be specified using the `Parameterized`
  * interface. Arguments can be given either as an object or a string, which
- * is assumed to contain a valid JS expression. Additionally, you can specify 
- * that the command is run multiple times by setting the `repeat` property. The 
- * property must be either a number, or a JS expression that evaluates to a 
- * number. If it evaluates to some other type, the expression is used as a 
+ * is assumed to contain a valid JS expression. Additionally, you can specify
+ * that the command is run multiple times by setting the `repeat` property. The
+ * property must be either a number, or a JS expression that evaluates to a
+ * number. If it evaluates to some other type, the expression is used as a
  * condition that is evaluated after the command is run. If the expression
  * returns a truthy value, the command is repeated.
  */
@@ -50,18 +50,18 @@ export interface Parameterized {
 }
 /**
  * A keymap is a dictionary of keys (characters) to actions. Keys are either
- * single characters or character ranges, denoted by sequences of `<char>,<char>` 
- * and `<char>-<char>`. Values of the dictionary can be also nested keymaps. 
- * This is how you can define commands that require  multiple keypresses. 
- * 
+ * single characters or character ranges, denoted by sequences of `<char>,<char>`
+ * and `<char>-<char>`. Values of the dictionary can be also nested keymaps.
+ * This is how you can define commands that require  multiple keypresses.
+ *
  * ![keymap example](../images/keymap.png)
- * When the value of a key is number, it refers to another keymap whose `id` 
- * equals the number. The number can also point to the same  keymap where it 
- * resides. With this mechanism, you can define _recursive_ keymaps that can 
+ * When the value of a key is number, it refers to another keymap whose `id`
+ * equals the number. The number can also point to the same  keymap where it
+ * resides. With this mechanism, you can define _recursive_ keymaps that can
  * take (theoretically) infinitely long key sequences. The picture on the right
  * illustrates this.
- * 
- * The `help` field contains help text that is shown in the status bar when the 
+ *
+ * The `help` field contains help text that is shown in the status bar when the
  * keymap is active.
  */
 export interface Keymap {
@@ -71,7 +71,7 @@ export interface Keymap {
 }
 /**
  * ## Cursor Shapes
- * 
+ *
  * You can use various cursor shapes in different modes. The list of available
  * shapes is defined below.
  */
@@ -93,11 +93,11 @@ let normalCursorStyle: vscode.TextEditorCursorStyle
 let searchCursorStyle: vscode.TextEditorCursorStyle
 /**
  * Another thing you can set in config, is whether ModalEdit starts in normal
- * mode. 
+ * mode.
  */
 let startInNormalMode: boolean
 /**
- * The root of the action configuration is keymap. This defines what key 
+ * The root of the action configuration is keymap. This defines what key
  * sequences will be run when keys are pressed in normal mode.
  */
 let rootKeymap: Keymap
@@ -112,7 +112,7 @@ let keymap: Keymap
  */
 let lastCommand: string
 /**
- * The key sequence that user has pressed is stored for error reporting 
+ * The key sequence that user has pressed is stored for error reporting
  * purposes and to make it available to command arguments.
  */
 let keySequence: string[] = []
@@ -122,7 +122,7 @@ let keySequence: string[] = []
 let keymapsById: { [id: number]: Keymap }
 /**
  * ## Configuration Accessors
- * 
+ *
  * The following functions return the current configuration settings.
  */
 export function getInsertCursorStyle(): vscode.TextEditorCursorStyle {
@@ -148,7 +148,7 @@ export function setLastCommand(command: string) {
 }
 /**
  * ## Logging
- * 
+ *
  * To enable logging and error reporting ModalEdit creates an output channel
  * that is visible in the output pane. The channel is created in the extension
  * activation hook, but it is passed to this module using the `setOutputChannel`
@@ -160,7 +160,7 @@ export function setOutputChannel(channel: vscode.OutputChannel) {
     outputChannel = channel
 }
 /**
- * Once the channel is set, we can output messages to it using the `log` 
+ * Once the channel is set, we can output messages to it using the `log`
  * function.
  */
 export function log(message: string) {
@@ -168,9 +168,9 @@ export function log(message: string) {
 }
 /**
  * ## Updating Configuration from settings.json
- * 
- * Whenever you save the user-level `settings.json` or the one located in the 
- * `.vsode` directory VS Code calls this function that updates the current 
+ *
+ * Whenever you save the user-level `settings.json` or the one located in the
+ * `.vsode` directory VS Code calls this function that updates the current
  * configuration.
  */
 export function updateFromConfig(): void {
@@ -206,13 +206,13 @@ export function updateFromConfig(): void {
  */
 let errors: number
 /**
- * The keymap ranges are recognized with the following regular expression. 
+ * The keymap ranges are recognized with the following regular expression.
  * Examples of valid key sequences include:
- * 
+ *
  * - `0-9`
  * - `a,b,c`
  * - `d,e-h,l`
- * 
+ *
  * Basically you can add individual characters to the range with a comma `,` and
  * an ASCII range with dash `-`. The ASCII code of the first character must be
  * smaller than the second one's.
@@ -220,7 +220,7 @@ let errors: number
 let keyRE = /^.([\-,].)+$/
 /**
  * The function itself is recursive; it calls itself, if it finds a nested
- * keymap. It stores all the keymaps it encounters in the `keymapsById` 
+ * keymap. It stores all the keymaps it encounters in the `keymapsById`
  * dictionary.
  */
 function validateAndResolveKeymaps(keybindings: Keymap) {
@@ -266,7 +266,7 @@ function validateAndResolveKeymaps(keybindings: Keymap) {
 }
 
 /**
- * The helper function below converts cursor styles specified in configuration 
+ * The helper function below converts cursor styles specified in configuration
  * to enumeration members used by VS Code.
  */
 function toVSCursorStyle(cursor: Cursor): vscode.TextEditorCursorStyle {
@@ -282,9 +282,9 @@ function toVSCursorStyle(cursor: Cursor): vscode.TextEditorCursorStyle {
 }
 /**
  * ## Type Predicates
- * 
+ *
  * Since JavaScript does not have dynamic type information we need to write
- * functions that check which type of action we get from the configuration. 
+ * functions that check which type of action we get from the configuration.
  * First we define a high-level type predicate that checks if a value is
  * an action.
  */
@@ -347,11 +347,11 @@ function isKeymap(x: any): x is Keymap {
 }
 /**
  * ## Executing Commands
- * 
+ *
  * In the end all keybindings will invoke one or more VS Code commands. The
  * following function runs a command whose name and arguments are given as
  * parameters. If the command throws an exception because of invalid arguments,
- * for example, the error is shown in the popup window at the corner of the 
+ * for example, the error is shown in the popup window at the corner of the
  * screen.
  */
 async function executeVSCommand(command: string, ...rest: any[]): Promise<void> {
@@ -406,14 +406,14 @@ async function executeConditional(cond: Conditional, selecting: boolean):
         await execute(cond[branch], selecting)
 }
 /**
- * Parameterized commands can get their arguments in two forms: as a string 
- * that is evaluated to get the actual arguments, or as an object. Before 
+ * Parameterized commands can get their arguments in two forms: as a string
+ * that is evaluated to get the actual arguments, or as an object. Before
  * executing the command, we inspect the `repeat` property. If it is string
- * we evaluate it, and check if the result is a number. If so, we update the 
+ * we evaluate it, and check if the result is a number. If so, we update the
  * `repeat` variable that designates repetition count. If not, we treate it as
- * a continue condition. The subroutine `exec` runs the command either `repeat` 
- * times or as long as the expression in the `repeat` property returns a truthy 
- * value. 
+ * a continue condition. The subroutine `exec` runs the command either `repeat`
+ * times or as long as the expression in the `repeat` property returns a truthy
+ * value.
  */
 async function executeParameterized(action: Parameterized, selecting: boolean) {
     let repeat: string | number = 1
@@ -434,7 +434,7 @@ async function executeParameterized(action: Parameterized, selecting: boolean) {
             let val = evalString(action.repeat, selecting)
             if (typeof val === 'number')
                 repeat = Math.max(1, val)
-            else 
+            else
                 repeat = action.repeat
         }
         else
@@ -451,11 +451,11 @@ async function executeParameterized(action: Parameterized, selecting: boolean) {
 }
 /**
  * ## Executing Actions
- * 
+ *
  * Before running any commands, we need to identify which type of action we got.
  * Depending on the type we use different function to execute the command. If
- * the action is not a command, it has to be a keymap. Since we resolved `id` 
- * referenences in `validateAndResolveKeymaps`, an action has to be a keymap 
+ * the action is not a command, it has to be a keymap. Since we resolved `id`
+ * referenences in `validateAndResolveKeymaps`, an action has to be a keymap
  * object at this point. We set the new keymap as the active one.
  */
 async function execute(action: Action, selecting: boolean): Promise<void> {
@@ -474,16 +474,16 @@ async function execute(action: Action, selecting: boolean): Promise<void> {
 }
 /**
  * ## Key Press Handler
- * 
+ *
  * Now that the plumbing of actions is implemented, it is straightforward to
  * map the pressed key to an action. The special case occurs when a command
- * captures the keyboard. Then we rerun the previous command and give the key 
+ * captures the keyboard. Then we rerun the previous command and give the key
  * to it as an argument.
- * 
+ *
  * Otherwise we just check if the current keymap contains binding for the key
  * pressed, and execute the action. If not, we present an error to the user.
- * 
- * As a last step the function returns `true`, if the handled key caused the 
+ *
+ * As a last step the function returns `true`, if the handled key caused the
  * `keySequence` to be cleared. This indicates that the key invoked a command
  * instead of just changing the active keymap.
  */
@@ -507,10 +507,10 @@ export async function handleKey(key: string, selecting: boolean,
 }
 /**
  * ## Keymap Help
- * 
+ *
  * When defining complex key sequences you can help the user by defining what
- * keys she can press next and what they do. If the help is defined, it is shown 
- * in the status bar. 
+ * keys she can press next and what they do. If the help is defined, it is shown
+ * in the status bar.
  */
 export function getHelp(): string | undefined {
     return keymap.help

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 /**
  * # Commands and State
- * 
+ *
  * This module implements the new commands provided by ModalEdit. It also stores
  * the extension state; which mode we are in, search parameters, bookmarks,
  * quick snippets, etc.
@@ -11,13 +11,13 @@ import * as actions from './actions'
 //#endregion
 /**
  * ## Command Arguments
- * 
- * Most commands provided by ModalEdit take arguments. Since command arguments 
+ *
+ * Most commands provided by ModalEdit take arguments. Since command arguments
  * are stored in objects by-design, we define them as interfaces.
- * 
+ *
  * ### Search Arguments
- * 
- * Search arguments are documented in the 
+ *
+ * Search arguments are documented in the
  * [README](../README.html#code-modaledit-search-code).
  */
 interface SearchArgs {
@@ -29,9 +29,9 @@ interface SearchArgs {
 }
 /**
  * ### Bookmark Arguments
- * 
- * [Bookmark](../README.html#bookmarks) ID is just an index in an array. The 
- * actual positions are stored in an object that conforms to the `Bookmark` 
+ *
+ * [Bookmark](../README.html#bookmarks) ID is just an index in an array. The
+ * actual positions are stored in an object that conforms to the `Bookmark`
  * interface in the `bookmarks` array.
  */
 interface BookmarkArgs {
@@ -44,7 +44,7 @@ interface Bookmark {
 }
 /**
  * ### Quick Snippet Arguments
- * 
+ *
  * [Quick snippets](../README.html#quick-snippets) are also stored in an array.
  * So their IDs are indexes as well.
  */
@@ -53,8 +53,8 @@ interface QuickSnippetArgs {
 }
 /**
  * ### Type Normal Keys Arguments
- * 
- * The [`typeNormalKeys` command](../README.html#invoking-key-bindings) gets the 
+ *
+ * The [`typeNormalKeys` command](../README.html#invoking-key-bindings) gets the
  * entered keys as a string.
  */
 interface TypeNormalKeysArgs {
@@ -62,22 +62,22 @@ interface TypeNormalKeysArgs {
 }
 /**
  * ### Select Between Arguments
- * 
- * The `selectBetween` command takes as arguments the strings/regular 
- * expressions which delimit the text to be selected. Both of them are optional, 
- * but in order for the command to do anything one of them needs to be defined. 
- * If the `from` argument is missing, the selection goes from the cursor 
- * position forwards to the `to` string. If the `to` is missing the selection 
- * goes backwards till the `from` string. 
- * 
+ *
+ * The `selectBetween` command takes as arguments the strings/regular
+ * expressions which delimit the text to be selected. Both of them are optional,
+ * but in order for the command to do anything one of them needs to be defined.
+ * If the `from` argument is missing, the selection goes from the cursor
+ * position forwards to the `to` string. If the `to` is missing the selection
+ * goes backwards till the `from` string.
+ *
  * If the `regex` flag is on, `from` and `to` strings are treated as regular
  * expressions in the search.
- * 
- * The `inclusive` flag tells if the delimiter strings are included in the 
- * selection or not. By default the delimiter strings are not part of the 
- * selection. Last, the `caseSensitive` flag makes the search case sensitive. 
+ *
+ * The `inclusive` flag tells if the delimiter strings are included in the
+ * selection or not. By default the delimiter strings are not part of the
+ * selection. Last, the `caseSensitive` flag makes the search case sensitive.
  * When this flag is missing or false the search is case insensitive.
- * 
+ *
  * By default the search scope is the current line. If you want search inside
  * the whole document, set the `docScope` flag.
  */
@@ -91,9 +91,9 @@ interface SelectBetweenArgs {
 }
 /**
  * ## State Variables
- * 
+ *
  * The enabler for modal editing is the `type` event that VS Code provides. It
- * reroutes the user's key presses to our extension. We store the handler to 
+ * reroutes the user's key presses to our extension. We store the handler to
  * this event in the `typeSubscription` variable.
  */
 let typeSubscription: vscode.Disposable | undefined
@@ -103,7 +103,7 @@ let typeSubscription: vscode.Disposable | undefined
  */
 let statusBarItem: vscode.StatusBarItem
 /**
- * This is the main mode flag that tells if we are in normal mode or insert 
+ * This is the main mode flag that tells if we are in normal mode or insert
  * mode.
  */
 let normalMode = true
@@ -112,8 +112,8 @@ let normalMode = true
  * it is not the only indicator that tells whether a selection is active.
  */
 let selecting = false
-/** 
- * The `searching` flag tells if `modaledit.search` command is in operation. 
+/**
+ * The `searching` flag tells if `modaledit.search` command is in operation.
  */
 let searching = false
 /**
@@ -146,7 +146,7 @@ let lastKeySequence: string[] = []
 let lastChange: string[] = []
 /**
  * ## Command Names
- * 
+ *
  * Since command names are easy to misspell, we define them as constants.
  */
 const toggleId = "modaledit.toggle"
@@ -169,7 +169,7 @@ const selectBetweenId = "modaledit.selectBetween"
 const repeatLastChangeId = "modaledit.repeatLastChange"
 /**
  * ## Registering Commands
- * 
+ *
  * The commands are registered when the extension is activated (main entry point
  * calls this function). We also create the status bar item.
  */
@@ -201,10 +201,10 @@ export function register(context: vscode.ExtensionContext) {
 }
 /**
  * ## Keyboard Event Handler
- * 
- * When the user types in normal mode, `onType` handler gets each typed 
+ *
+ * When the user types in normal mode, `onType` handler gets each typed
  * character one at a time. It calls the `runActionForKey` subroutine to invoke
- * the action bound to the typed key. In addition, it updates the state 
+ * the action bound to the typed key. In addition, it updates the state
  * variables needed by the `repeatLastChange` command and the status bar.
  */
 async function onType(event: { text: string }) {
@@ -221,18 +221,18 @@ async function onType(event: { text: string }) {
 }
 /**
  * Whenever text changes in an active editor, we set a flag. This flag is
- * examined in the `onType` handler above, and the `lastChange` variable is set 
+ * examined in the `onType` handler above, and the `lastChange` variable is set
  * to indicate that the last command that changed editor text.
  */
 export function onTextChanged() {
     textChanged = true
 }
 /**
- * This helper function just calls the `handleKey` function in the `actions` 
+ * This helper function just calls the `handleKey` function in the `actions`
  * module. It checks if we have an active selection or search mode on, and
- * passes that information to the function. `handleKey` returns `true` if the 
- * key actually invoked a command, or `false` if it was a part of incomplete 
- * key sequence that did not (yet) cause any commands to run. This information 
+ * passes that information to the function. `handleKey` returns `true` if the
+ * key actually invoked a command, or `false` if it was a part of incomplete
+ * key sequence that did not (yet) cause any commands to run. This information
  * is needed to decide whether the `lastKeySequence` variable is updated.
  */
 async function runActionForKey(key: string): Promise<boolean> {
@@ -240,7 +240,7 @@ async function runActionForKey(key: string): Promise<boolean> {
 }
 /**
  * ## Mode Switching  Commands
- * 
+ *
  * `toggle` switches between normal and insert mode.
  */
 export function toggle() {
@@ -251,11 +251,11 @@ export function toggle() {
 }
 /**
  * When entering normal mode, we:
- * 
+ *
  * 1. cancel the search, if it is on,
  * 2. subscribe to the `type` event,
  * 3. handle the rest of the mode setup with `setNormalMode` function, and
- * 4. clear the selection. 
+ * 4. clear the selection.
  */
 export function enterNormal() {
     cancelSearch()
@@ -266,13 +266,13 @@ export function enterNormal() {
 }
 /**
  * Conversely, when entering insert mode, we:
- * 
+ *
  * 1. cancel the search, if it is on (yes, you can use it in insert mode, too),
  * 2. unsubscribe to the `type` event,
  * 3. handle the rest of the mode setup with `setNormalMode` function.
- * 
+ *
  * Note that we specifically don't clear the selection. This allows the user
- * to easily surround selected text with hyphens `'`, parenthesis `(` and `)`, 
+ * to easily surround selected text with hyphens `'`, parenthesis `(` and `)`,
  * brackets `[` and `]`, etc.
  */
 export function enterInsert() {
@@ -285,8 +285,8 @@ export function enterInsert() {
 }
 /**
  * The rest of the state handling is delegated to subroutines that do specific
- * things. `setNormalMode` sets or resets the VS Code `modaledit.normal` context. 
- * This can be used in "standard" key bindings. Then it sets the `normalMode` 
+ * things. `setNormalMode` sets or resets the VS Code `modaledit.normal` context.
+ * This can be used in "standard" key bindings. Then it sets the `normalMode`
  * variable and calls the next subroutine which updates cursor and status bar.
  */
 async function setNormalMode(value: boolean): Promise<void> {
@@ -312,7 +312,7 @@ export function updateCursorAndStatusBar(editor: vscode.TextEditor | undefined) 
 }
 /**
  * The last function updates the status bar text according to the mode. It also
- * indicates if selection is active or if search mode on. If so, it shows the 
+ * indicates if selection is active or if search mode on. If so, it shows the
  * search parameters. If no editor is active, we hide the status bar item.
  */
 export function updateStatusBar(editor: vscode.TextEditor | undefined,
@@ -336,11 +336,11 @@ export function updateStatusBar(editor: vscode.TextEditor | undefined,
 }
 /**
  * ## Selection Commands
- * 
+ *
  * `modaledit.cancelSelection` command clears the selection using ths standard
  * `cancelSelection` command, but also sets the `selecting` flag to false, and
  * updates the status bar. It is advisable to use this command instead of the
- * standard version to keep the state in sync. 
+ * standard version to keep the state in sync.
  */
 async function cancelSelection(): Promise<void> {
     await vscode.commands.executeCommand("cancelSelection")
@@ -349,7 +349,7 @@ async function cancelSelection(): Promise<void> {
 }
 /**
  * `modaledit.toggleSelection` toggles the selection mode on and off. It sets
- * the selection mode flag and updates the status bar, but also clears the 
+ * the selection mode flag and updates the status bar, but also clears the
  * selection.
  */
 async function toggleSelection(): Promise<void> {
@@ -360,7 +360,7 @@ async function toggleSelection(): Promise<void> {
 }
 /**
  * The following helper function actually determines, if a selection is active.
- * It checks not only the `selecting` flag but also if there is any text 
+ * It checks not only the `selecting` flag but also if there is any text
  * selected in the active editor.
  */
 function isSelecting(): boolean {
@@ -370,12 +370,12 @@ function isSelecting(): boolean {
 }
 /**
  * ## Search Commands
- * 
+ *
  * Incremental search is by far the most complicated part of this extension.
  * Searching overrides both normal and insert modes, and captures the keyboard
- * until it is done. The following subroutine sets the associated state 
+ * until it is done. The following subroutine sets the associated state
  * variable, the VS Code `modaledit.searching` context, and the status bar.
- * Since search mode also puts the editor implicitly in the normal mode, we 
+ * Since search mode also puts the editor implicitly in the normal mode, we
  * need to check what was the state when we initiated the search. If we were in
  * insert mode, we return also there.
  */
@@ -458,8 +458,8 @@ function highlightNextMatch(editor: vscode.TextEditor, startPos: vscode.Position
     }
     else {
         /**
-         * Otherwise we first map the cursor position to the starting offset 
-         * from the begining of the file. We add the delta argument to the 
+         * Otherwise we first map the cursor position to the starting offset
+         * from the begining of the file. We add the delta argument to the
          * offset.
          */
         let doc = editor.document
@@ -477,7 +477,7 @@ function highlightNextMatch(editor: vscode.TextEditor, startPos: vscode.Position
         let target = searchCaseSensitive ?
             newSearchString : newSearchString.toLowerCase()
         /**
-         * This is the actual search. Depending on the search direction we 
+         * This is the actual search. Depending on the search direction we
          * find either the first or the last match from the start offset.
          */
         let offs = searchBackwards ?
@@ -502,8 +502,8 @@ function highlightNextMatch(editor: vscode.TextEditor, startPos: vscode.Position
 }
 /**
  * ### Accepting Search
- * 
- * Accepting the search resets the mode variables. Additionally, if 
+ *
+ * Accepting the search resets the mode variables. Additionally, if
  * `typeAfterAccept` argument is set we run the given normal mode commands.
  */
 async function acceptSearch() {
@@ -517,7 +517,7 @@ async function typeAfterMatch() {
 }
 /**
  * ### Canceling Search
- * 
+ *
  * Canceling search just resets state, and moves the cursor back to the starting
  * position.
  */
@@ -531,7 +531,7 @@ async function cancelSearch(): Promise<void> {
 }
 /**
  * ### Modifying Search String
- * 
+ *
  * Since we cannot capture the backspace character in normal mode, we have to
  * hook it another way. We define a command `modaledit.deleteCharFromSearch`
  * which deletes the last character from the search string. This command can
@@ -554,11 +554,11 @@ function deleteCharFromSearch() {
 }
 /**
  * ### Finding Previous and Next Match
- * 
- * Given all the code we already have for searching, finding next and previous 
- * match is a relatively simple task. We basically just calculate the new 
- * starting position and restart the search. The selection is what determines 
- * where the search starts, but we need to adjust the starting position slightly 
+ *
+ * Given all the code we already have for searching, finding next and previous
+ * match is a relatively simple task. We basically just calculate the new
+ * starting position and restart the search. The selection is what determines
+ * where the search starts, but we need to adjust the starting position slightly
  * depending on the search direction and other parameters.
  */
 async function nextMatch(): Promise<void> {
@@ -589,7 +589,7 @@ async function previousMatch(): Promise<void> {
 }
 /**
  * ## Bookmarks
- * 
+ *
  * Defining a bookmark is simple. We just store the cursor location and file in
  * a `Bookmark` object, and store it in the `bookmarks` array.
  */
@@ -617,7 +617,7 @@ async function goToBookmark(args?: BookmarkArgs): Promise<void> {
 }
 /**
  * ## Quick Snippets
- * 
+ *
  * Supporting quick snippets is also a pleasantly simple job. First we implement
  * the `modaledit.fillSnippetArgs` command, which replaces (multi-)selection
  * ranges with `$1`, `$2`, ...
@@ -642,7 +642,7 @@ function defineQuickSnippet(args?: QuickSnippetArgs) {
             editor.document.getText(editor.selection)
 }
 /**
- * Inserting a snippet is done as easily with the built-in command. We enter 
+ * Inserting a snippet is done as easily with the built-in command. We enter
  * insert mode automatically before snippet is expanded.
  */
 async function insertQuickSnippet(args?: QuickSnippetArgs): Promise<void> {
@@ -656,8 +656,8 @@ async function insertQuickSnippet(args?: QuickSnippetArgs): Promise<void> {
 }
 /**
  * ## Invoking Commands via Key Bindings
- * 
- * The last command runs normal mode commands throught their key bindings. 
+ *
+ * The last command runs normal mode commands throught their key bindings.
  * Implementing that is as easy as calling the keyboard handler.
  */
 async function typeNormalKeys(args: TypeNormalKeysArgs): Promise<void> {
@@ -668,9 +668,9 @@ async function typeNormalKeys(args: TypeNormalKeysArgs): Promise<void> {
 }
 /**
  * ## Advanced Selection Command
- * 
+ *
  * For selecting ranges of text between two characters (inside parenthesis, for
- * ecample) we add the `modaledit.selectBetween` command. 
+ * ecample) we add the `modaledit.selectBetween` command.
  */
 function selectBetween(args: SelectBetweenArgs) {
     let editor = vscode.window.activeTextEditor
@@ -730,11 +730,11 @@ function selectBetween(args: SelectBetweenArgs) {
 }
 /**
  * ## Repeat Last Change Command
- * 
- * The `repeatLastChange` command runs the key sequence stored in `lastChange` 
- * variable. Since the command inevitably causes text in the editor to change 
- * (which causes the `textChanged` flag to go high), it has to reset the current 
- * key sequence to prevent the `lastChange` variable from being overwritten next 
+ *
+ * The `repeatLastChange` command runs the key sequence stored in `lastChange`
+ * variable. Since the command inevitably causes text in the editor to change
+ * (which causes the `textChanged` flag to go high), it has to reset the current
+ * key sequence to prevent the `lastChange` variable from being overwritten next
  * time the user presses a key.
  */
 async function repeatLastChange(): Promise<void> {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -120,7 +120,7 @@ let searching = false
  * The search parameters are stored below.
  */
 let searchString: string
-let searchStartPos: vscode.Position
+let searchStartPos: vscode.Position[]
 let searchBackwards = false
 let searchCaseSensitive = false
 let searchAcceptAfter = Number.POSITIVE_INFINITY
@@ -216,6 +216,41 @@ async function onType(event: { text: string }) {
     if (await runActionForKey(event.text)) {
         lastKeySequence = currentKeySequence
         currentKeySequence = []
+<<<<<<< HEAD
+=======
+        for(let label in keySeqRegistry){
+            let register = keySeqRegistry[label]
+            if (register.recording){
+                if(register.skipRecording){
+                    register.skipRecording = false;
+                    continue;
+                }
+                if(!register.stopping) register.reqSeq.push(lastKeySequence)
+                else{
+                    // actions.log("include last? "+register.includeLastCommand)
+                    // actions.log("last key: "+lastKeySequence)
+                    if(register.includeLastCommand)
+                        register.reqSeq.push(lastKeySequence)
+
+                    // actions.log("include first? "+register.includeFirstCommand)
+
+                    if(register.includeFirstCommand){
+                        register.seq = register.reqSeq;
+                    }else{
+                        register.seq = register.reqSeq.slice(1)
+                    }
+                    register.reqSeq = [];
+                    register.recording = false;
+                    register.stopping = false;
+
+                    actions.log("key sequence: ")
+                    for(let i=0;i<register.seq.length;i++){
+                        actions.log("action: "+register.seq[i].join());
+                    }
+                }
+            }
+        }
+>>>>>>> fixed bug in multi-letter search
     }
     updateStatusBar(vscode.window.activeTextEditor, actions.getHelp())
 }
@@ -391,8 +426,8 @@ async function setSearching(value: boolean) {
  * This helper function changes the selection range in the active editor. It
  * also makes sure that the selection is visible.
  */
-function changeSelection(editor: vscode.TextEditor, anchor: vscode.Position,
-    active: vscode.Position) {
+function changeSelection(sel: vscode.Selection, editor: vscode.TextEditor,
+    anchor: vscode.Position, active: vscode.Position) {
     editor.selection = new vscode.Selection(anchor, active)
     editor.revealRange(editor.selection)
 }
@@ -419,7 +454,7 @@ async function search(args: SearchArgs | string): Promise<void> {
             enterNormal()
         setSearching(true)
         searchString = ""
-        searchStartPos = editor.selection.active
+        searchStartPos = editor.selections.map(x => x.active)
         searchBackwards = args.backwards || false
         searchCaseSensitive = args.caseSensitive || false
         searchAcceptAfter = args.acceptAfter || Number.POSITIVE_INFINITY
@@ -437,7 +472,7 @@ async function search(args: SearchArgs | string): Promise<void> {
          * the next match. If `acceptAfter` argument is given, and we have a
          * sufficiently long search string, we accept the search automatically.
          */
-        highlightNextMatch(editor, editor.selection.anchor, searchString + args)
+        highlightNextMatch(editor, editor.selections.map(x => x.anchor), searchString + args)
         if (searchString.length >= searchAcceptAfter)
             await acceptSearch()
     }
@@ -447,57 +482,65 @@ async function search(args: SearchArgs | string): Promise<void> {
  * the start position for the search, the search string, and an optional delta
  * parameter that increments or decrements the start position.
  */
-function highlightNextMatch(editor: vscode.TextEditor, startPos: vscode.Position,
+function highlightNextMatch(editor: vscode.TextEditor, startPos: vscode.Position[],
     newSearchString: string, delta: number = 0) {
     if (newSearchString == "") {
         /**
          * If search string is empty, we return to the start position.
          */
-        changeSelection(editor, searchStartPos, searchStartPos)
+        editor.selections = editor.selections.map((sel, i) =>
+            new vscode.Selection(searchStartPos[i],searchStartPos[i]))
+        editor.revealRange(editor.selection)
         searchString = newSearchString
     }
     else {
-        /**
-         * Otherwise we first map the cursor position to the starting offset
-         * from the begining of the file. We add the delta argument to the
-         * offset.
-         */
-        let doc = editor.document
-        let startOffs = doc.offsetAt(startPos) + delta
-        /**
-         * Then we get the text of the active editor as string. If we have
-         * case-insensitive search, we transform the text to lower case.
-         */
-        let docText = searchCaseSensitive ?
-            doc.getText() : doc.getText().toLowerCase()
-        /**
-         * Next we determine the search target. It is also transformed to lower
-         * case, if search is case-insensitive.
-         */
-        let target = searchCaseSensitive ?
-            newSearchString : newSearchString.toLowerCase()
-        /**
-         * This is the actual search. Depending on the search direction we
-         * find either the first or the last match from the start offset.
-         */
-        let offs = searchBackwards ?
-            docText.lastIndexOf(target, startOffs) :
-            docText.indexOf(target, startOffs)
-        if (offs >= 0) {
+        editor.selections = editor.selections.map((sel, i) => {
             /**
-             * If search was successful, we store the new search string and
-             * change the selection to highlight it. If `selectTillMatch`
-             * parameter is set, we highlight the range from the search start
-             * position to the beginning or end of the match depending on if
-             * the match is before or after the starting position.
+             * Otherwise we first map the cursor position to the starting offset
+             * from the begining of the file. We add the delta argument to the
+             * offset.
              */
-            searchString = newSearchString
-            let newPos = doc.positionAt(offs)
-            let start = searchSelectTillMatch ? searchStartPos : newPos
-            changeSelection(editor, start,
-                newPos.with(undefined, newPos.character +
-                    (newPos.isBefore(start) ? 0 : searchString.length)))
-        }
+            let doc = editor.document
+            let startOffs = doc.offsetAt(startPos[i]) + delta
+            /**
+             * Then we get the text of the active editor as string. If we have
+             * case-insensitive search, we transform the text to lower case.
+             */
+            let docText = searchCaseSensitive ?
+                doc.getText() : doc.getText().toLowerCase()
+            /**
+             * Next we determine the search target. It is also transformed to lower
+             * case, if search is case-insensitive.
+             */
+            let target = searchCaseSensitive ?
+                newSearchString : newSearchString.toLowerCase()
+            /**
+             * This is the actual search. Depending on the search direction we
+             * find either the first or the last match from the start offset.
+             */
+            let offs = searchBackwards ?
+                docText.lastIndexOf(target, startOffs) :
+                docText.indexOf(target, startOffs)
+            if (offs >= 0) {
+                /**
+                 * If search was successful, we store the new search string and
+                 * change the selection to highlight it. If `selectTillMatch`
+                 * parameter is set, we highlight the range from the search start
+                 * position to the beginning or end of the match depending on if
+                 * the match is before or after the starting position.
+                 */
+                searchString = newSearchString
+                let newPos = doc.positionAt(offs)
+                let start = searchSelectTillMatch ? searchStartPos[i] : newPos
+                let newSel = new vscode.Selection(start,
+                    newPos.with(undefined, newPos.character +
+                        (newPos.isBefore(start) ? 0 : searchString.length)))
+                return newSel
+            }else{
+                return sel
+            }
+        })
+        editor.revealRange(editor.selection)
     }
 }
 /**
@@ -525,8 +568,14 @@ async function cancelSearch(): Promise<void> {
     if (searching) {
         await setSearching(false)
         let editor = vscode.window.activeTextEditor
-        if (editor)
-            changeSelection(editor, searchStartPos, searchStartPos)
+        if (editor){
+            editor.selections = editor.selections.map((sel,i) => {
+                let newSel =
+                    new vscode.Selection(searchStartPos[i],searchStartPos[i])
+                return newSel
+            })
+            editor.revealRange(editor.selection)
+        }
     }
 }
 /**
@@ -564,17 +613,17 @@ function deleteCharFromSearch() {
 async function nextMatch(): Promise<void> {
     let editor = vscode.window.activeTextEditor
     if (editor && searchString) {
-        let s = editor.selection
+        let s = editor.selections
         if (searchBackwards)
-            highlightNextMatch(editor, s.active, searchString,
-                (searchSelectTillMatch && s.active.isBefore(searchStartPos)) ||
-                    s.isEmpty ? -1 :
+            highlightNextMatch(editor, s.map(x => x.active), searchString,
+                (searchSelectTillMatch && s[0].active.isBefore(searchStartPos[0])) ||
+                    s[0].isEmpty ? -1 :
                     -searchString.length - 1)
         else
-            highlightNextMatch(editor, s.active, searchString,
-                searchSelectTillMatch && s.active.isBefore(searchStartPos) ?
+            highlightNextMatch(editor, s.map(x => x.active), searchString,
+                searchSelectTillMatch && s[0].active.isBefore(searchStartPos[0]) ?
                     searchString.length :
-                    s.isEmpty ? 1 : 0)
+                    s[0].isEmpty ? 1 : 0)
         await typeAfterMatch()
     }
 }
@@ -611,8 +660,10 @@ async function goToBookmark(args?: BookmarkArgs): Promise<void> {
     if (bm) {
         await vscode.window.showTextDocument(bm.document)
         let editor = vscode.window.activeTextEditor
-        if (editor)
-            changeSelection(editor, bm.position, bm.position)
+        if (editor){
+            editor.selection = new vscode.Selection(bm.position, bm.position)
+            editor.revealRange(editor.selection)
+        }
     }
 }
 /**
@@ -726,7 +777,9 @@ function selectBetween(args: SelectBetweenArgs) {
                 startOffs + toOffs + (args.inclusive ? args.to.length : 0)
         }
     }
-    changeSelection(editor, doc.positionAt(fromOffs), doc.positionAt(toOffs))
+    editor.selection = new vscode.Selection(
+        doc.positionAt(fromOffs), doc.positionAt(toOffs))
+    editor.revealRange(editor.selection)
 }
 /**
  * ## Repeat Last Change Command

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,13 @@
 /**
  * # Extension Entry Point
- * 
+ *
  * The module `vscode` contains the VS Code extensibility API. The other
  * modules are part of the extension.
  */
 import * as vscode from 'vscode'
 import * as actions from './actions'
 import * as commands from './commands'
-/** 
+/**
  * This method is called when the extension is activated. The activation events
  * are set in the `package.json` like this:
  * ```js
@@ -16,41 +16,41 @@ import * as commands from './commands'
  * which means that the extension is activated as soon as VS Code is running.
  */
 export function activate(context: vscode.ExtensionContext) {
-	/**
-	 * The commands are defined in the `package.json` file. We register them
-	 * with function defined in the `commands` module. 
-	 */
-	commands.register(context)
-	/**
-	 * We create an output channel for diagnostic messages and pass it to the
-	 * `actions` module.
-	 */
-	let channel = vscode.window.createOutputChannel("ModalEdit")
-	actions.setOutputChannel(channel)
-	/**
-	 * Then we subscribe to events we want to react to.
-	 */
-	context.subscriptions.push(
-		channel,
-		vscode.workspace.onDidChangeConfiguration(actions.updateFromConfig),
-		vscode.window.onDidChangeVisibleTextEditors(editors =>
-			editors.forEach(commands.updateCursorAndStatusBar)),
-		vscode.window.onDidChangeTextEditorSelection(e =>
-			commands.updateStatusBar(e.textEditor)),
-		vscode.workspace.onDidChangeTextDocument(commands.onTextChanged))
-	/**
-	 * Next we update the active settings from the config file, and at last, 
-	 * we enter into normal or edit mode depending on the settings.
-	 */
-	actions.updateFromConfig()
-	if (actions.getStartInNormalMode())
-		commands.enterNormal()
-	else
-		commands.enterInsert()
+    /**
+     * The commands are defined in the `package.json` file. We register them
+     * with function defined in the `commands` module.
+     */
+    commands.register(context)
+    /**
+     * We create an output channel for diagnostic messages and pass it to the
+     * `actions` module.
+     */
+    let channel = vscode.window.createOutputChannel("ModalEdit")
+    actions.setOutputChannel(channel)
+    /**
+     * Then we subscribe to events we want to react to.
+     */
+    context.subscriptions.push(
+        channel,
+        vscode.workspace.onDidChangeConfiguration(actions.updateFromConfig),
+        vscode.window.onDidChangeVisibleTextEditors(editors =>
+            editors.forEach(commands.updateCursorAndStatusBar)),
+        vscode.window.onDidChangeTextEditorSelection(e =>
+            commands.updateStatusBar(e.textEditor)),
+        vscode.workspace.onDidChangeTextDocument(commands.onTextChanged))
+    /**
+     * Next we update the active settings from the config file, and at last,
+     * we enter into normal or edit mode depending on the settings.
+     */
+    actions.updateFromConfig()
+    if (actions.getStartInNormalMode())
+        commands.enterNormal()
+    else
+        commands.enterInsert()
 }
-/** 
+/**
  * This method is called when your extension is deactivated
  */
 export function deactivate() {
-	commands.enterInsert()
+    commands.enterInsert()
 }


### PR DESCRIPTION
Hi There!

First of all, thanks for the great extension! I love it, and use it daily. The clarity of your tutorial and documentation made this a joy to extend for my own purposes. 

Here is a change that makes it possible to use multiple cursors with the search command. The idea is that it allows you to emulate commands like `f` and `d` in vim for each cursor. I am making use of it in my daily work now.

I also have been working on an ability to record "macros"; right now it only records normal mode keys, but seems like it should be possible to handle insert mode recording as well (though I don't know if it would be perfect). I will create a separate pull request for that once I am happy with the functionality.