### PR TITLE
New commands: reset and enable selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Modal Editing in VS Code
 
 ModalEdit is a simple but powerful extension that adds configurable "normal"
-mode to VS Code. The most prominent [modal editor][1] is [Vim][2], which also 
+mode to VS Code. The most prominent [modal editor][1] is [Vim][2], which also
 inspired the development of ModalEdit. It includes Vim commands as presets
-you can import, but ModalEdit's true power comes with its configurability. You 
-can emulate existing editors like Vim or [Kakoune][8] or build your keyboard 
-layout from ground up and add exactly the features you need.  
+you can import, but ModalEdit's true power comes with its configurability. You
+can emulate existing editors like Vim or [Kakoune][8] or build your keyboard
+layout from ground up and add exactly the features you need.
 
-As in Vim, the goal of the extension is to save your keystrokes and make 
-editing as efficient as possible. Unlike most Vim emulators, ModalEdit leverages 
-the built-in features of VS Code. You define your keybindings using commands 
-provided by VS Code and other extensions. You can build complex operations by 
-arranging commands into sequences. You can define conditional commands that do 
-different things based on editor state. Also, you can map these commands to 
+As in Vim, the goal of the extension is to save your keystrokes and make
+editing as efficient as possible. Unlike most Vim emulators, ModalEdit leverages
+the built-in features of VS Code. You define your keybindings using commands
+provided by VS Code and other extensions. You can build complex operations by
+arranging commands into sequences. You can define conditional commands that do
+different things based on editor state. Also, you can map these commands to
 arbitrarily long keyboard sequences.
 
 > Version 2.0 is the latest major release, and it contains many improvements
@@ -22,25 +22,25 @@ arbitrarily long keyboard sequences.
 
 ## Getting Started
 
-When extension is installed text documents will open in normal mode. The 
+When extension is installed text documents will open in normal mode. The
 current mode is shown in the status bar. You can switch between modes by
 clicking the pane in the status bar.
 
 ![Status bar](images/status-bar.gif)
 
-In normal mode keys don't output characters but invoke commands. You can 
-specify these commands in the `settings.json` file. To edit your user-level 
-settings file, open command palette with `Ctrl+Shift+P` and look up command 
-**Preferences: Open Settings (JSON)**. If you want the configuration to be 
-project specific, edit the `settings.json` that is located in the `.vscode` 
-directory under your project directory. 
+In normal mode keys don't output characters but invoke commands. You can
+specify these commands in the `settings.json` file. To edit your user-level
+settings file, open command palette with `Ctrl+Shift+P` and look up command
+**Preferences: Open Settings (JSON)**. If you want the configuration to be
+project specific, edit the `settings.json` that is located in the `.vscode`
+directory under your project directory.
 
-> You might want to skip to the [tutorial][9], if you prefer learning by 
-> example. If you want to start with Vim keybindings, you'll find the 
+> You might want to skip to the [tutorial][9], if you prefer learning by
+> example. If you want to start with Vim keybindings, you'll find the
 > instructions [here][14]. Otherwise keep reading this document.
 
-To define the key mappings used in normal mode, add a property named 
-`modaledit.keybindings`. You should define at least one binding that will switch 
+To define the key mappings used in normal mode, add a property named
+`modaledit.keybindings`. You should define at least one binding that will switch
 the editor to the *insert mode*, which is the same as VS Code's default mode.
 ```js
 "modaledit.keybindings": {
@@ -51,14 +51,14 @@ When you save the `settings.json` file, keybindings take effect immediately.
 
 ModalEdit adds a regular VS Code keyboard shortcut for `Esc` to return back to
 normal mode. If you wish, you can remap this command to another key by
-pressing `Ctrl+K Ctrl+S`. 
+pressing `Ctrl+K Ctrl+S`.
 
 ### Selections/Visual Mode
 
 ModalEdit does not have a separate selection/visual mode as Vim has. It is
-possible to select text both in normal mode and insert mode. However, since it 
-is typical that commands in normal have different behavior when selection is 
-active, the status bar text changes to indicate that. You can change the text 
+possible to select text both in normal mode and insert mode. However, since it
+is typical that commands in normal have different behavior when selection is
+active, the status bar text changes to indicate that. You can change the text
 shown in status bar using [configuration parameters](#changing-status-bar)
 
 ![Selection active](images/selected-text.png)
@@ -97,14 +97,14 @@ executed by defining an object with prefined properties:
     "repeat": number | "<JS expression>"
 }
 ```
-The `<command>` is again a valid VS Code command. The `args` property contains 
+The `<command>` is again a valid VS Code command. The `args` property contains
 whatever arguments the command takes. It can be specified as a JSON object
-or as a string. If the value of the `args` property is a string, ModalEdit 
-treats it as a JavaScript expression. It evaluates the expression and passes the 
-result to the command. The following variables can be used inside expression 
+or as a string. If the value of the `args` property is a string, ModalEdit
+treats it as a JavaScript expression. It evaluates the expression and passes the
+result to the command. The following variables can be used inside expression
 strings:
 
-| Variable        | Type       | Description 
+| Variable        | Type       | Description
 | --------------- | ---------- | -------------------------------------------------
 | `__file`        | `string`   | The file name of the document that is edited.
 | `__line`        | `number`   | The line number where the cursor is currently on.
@@ -112,24 +112,24 @@ strings:
 | `__char`        | `string`   | The character under the cursor.
 | `__selection`   | `string`   | Currently selected text.
 | `__selecting`   | `boolean`  | Flag that indicates whether selection is active.
-| `__keySequence` | `string[]` | Array of keys that were pressed to invoke the command. 
+| `__keySequence` | `string[]` | Array of keys that were pressed to invoke the command.
 | `__keys`        | `string[]` | Alias to the `__keySequence` variable.
 | `__rkeys`       | `string[]` | Contains the `__keys` array reversed. This is handy when you want to access the last characters of the array as they will be first in `__rkeys`.
-| `__cmd`         | `string`   | Containst the `__keys` array joined together to a string. Now you don't have to do this explicitly in you expressions. 
+| `__cmd`         | `string`   | Containst the `__keys` array joined together to a string. Now you don't have to do this explicitly in you expressions.
 | `__rcmd`        | `string`   | Containst the `__rkeys` array joined together to a string.
 
 The `repeat` property allows you to run the command multiple times. If the value
-of the property is a number, it directly determines the repetition count. If it 
-is a string, ModalEdit evaluates it as JS expression and checks if the result is 
-a number. In that case the returned number is used as the repeat count. Note 
-that numbers smaller than 1 will be ignored, and the command is always run at 
+of the property is a number, it directly determines the repetition count. If it
+is a string, ModalEdit evaluates it as JS expression and checks if the result is
+a number. In that case the returned number is used as the repeat count. Note
+that numbers smaller than 1 will be ignored, and the command is always run at
 least once.
 
-If returned value is not a number, the expression is treated as a condition that 
-is evaluated after the command has run. The command is repeated as long as the 
+If returned value is not a number, the expression is treated as a condition that
+is evaluated after the command has run. The command is repeated as long as the
 expression returns a truthy value.
 
-Below is an example that maps key `o` to a command that moves the cursor to the 
+Below is an example that maps key `o` to a command that moves the cursor to the
 end of line. It also selects the jumped range, if we have selection active.
 ```js
 "o": {
@@ -140,8 +140,8 @@ end of line. It also selects the jumped range, if we have selection active.
 
 ### Sequence of Commands
 
-To construct more complex operations consisting of multiple steps, you can 
-define command sequences. Commands in a sequence will be run one after another. 
+To construct more complex operations consisting of multiple steps, you can
+define command sequences. Commands in a sequence will be run one after another.
 A sequence is defined as an array.
 ```js
 "<key>": [ <command1>, <command2>, ... ]
@@ -150,7 +150,7 @@ In above, `<command>` can assume any of the supported forms: single command,
 one with arguments, or conditional command (see below).
 
 The next example maps the `f` key to a command sequence that first deletes the
-selected text and then switch to insert mode. It corresponds to the `c` command 
+selected text and then switch to insert mode. It corresponds to the `c` command
 in Vim.
 ```js
 "f": [
@@ -161,9 +161,9 @@ in Vim.
 
 ### Conditional Commands
 
-For even more complex scenarios, you can define commands that run different 
-commands depending on a specified condition. The most common use case for this 
-is to run a different command when selection is active. The format of a 
+For even more complex scenarios, you can define commands that run different
+commands depending on a specified condition. The most common use case for this
+is to run a different command when selection is active. The format of a
 conditional commands is:
 ```js
 "<key>":  {
@@ -173,16 +173,16 @@ conditional commands is:
     ...
 }
 ```
-Here `<condition>` can be any valid JavaScript expression. You can use 
-variables listed in the "Commands with Arguments" section in the expression. If 
-the expression evaluates to `<result1>`, `<command1>` will be executed, if to 
+Here `<condition>` can be any valid JavaScript expression. You can use
+variables listed in the "Commands with Arguments" section in the expression. If
+the expression evaluates to `<result1>`, `<command1>` will be executed, if to
 `<result2>`, `<command2>` will be run, and so forth. If none of the defined
-properties match the expression result, nothing is done. Commands can be of any 
-kind: a single command, sequence, or command with arguments. 
+properties match the expression result, nothing is done. Commands can be of any
+kind: a single command, sequence, or command with arguments.
 
 Below is an example that moves cursor one word forward with `w` key. We use
-the `__selecting` variable to determine if a selection is active. If so, we 
-extend the selection using `cursorWordStartRightSelect` command, otherwise we 
+the `__selecting` variable to determine if a selection is active. If so, we
+extend the selection using `cursorWordStartRightSelect` command, otherwise we
 just jump to next word with `cursorWordStartRight`.
 ```js
 "w": {
@@ -194,7 +194,7 @@ just jump to next word with `cursorWordStartRight`.
 
 ### Binding Key Sequences
 
-When you want to define a multi-key sequence, nest the key bindings. You can 
+When you want to define a multi-key sequence, nest the key bindings. You can
 define a two key command using the following format.
 ```js
 "<key1>": {
@@ -212,7 +212,7 @@ The example below defines two commands that are bound to key sequences `g - f`
         "command": "modaledit.search",
         "args": {}
     },
-    "b": 
+    "b":
         "command": "modaledit.search",
         "args": {
             "backwards": true
@@ -233,7 +233,7 @@ functionality.
 
 You can add multiple characters to a keybinding comma `,` and dash `-`. For
 example, `a,b` bind both `a` and `b` to the same action. You can also add ranges
-like any numeric character `0-9`. The ASCII code of the first character must be 
+like any numeric character `0-9`. The ASCII code of the first character must be
 smaller than the second one's. You can also combine these notations; for
 instance, range `a,d-f` maps keys `a`, `d`, `e`, and `f` to a same action.
 
@@ -241,11 +241,11 @@ instance, range `a,d-f` maps keys `a`, `d`, `e`, and `f` to a same action.
 
 By giving keymap a numeric ID, you can refer to it in another (or same) keymap.
 With key ranges, this allows you to create a binding that can take theoretically
-infinitely long key sequence. The example below shows how you can define 
+infinitely long key sequence. The example below shows how you can define
 commands like `3w` that moves the cursor forward by three words. First we define
-the commands that moves or select the previous/next word (with keys `b` and `w`), 
-and then we create a binding that matches a positive number using key ranges and 
-a recursive keymap. We also use the 
+the commands that moves or select the previous/next word (with keys `b` and `w`),
+and then we create a binding that matches a positive number using key ranges and
+a recursive keymap. We also use the
 [`modaledit.typeNormalKeys` command](#invoking-key-bindings) to invoke the
 existing key bindings and the [`repeat` property](#commands-with-arguments) to
 repeat the command.
@@ -271,66 +271,66 @@ repeat the command.
             }
         }
 ```
-We give the keymap attached to key range `1-9` the `id` of 1. When that keymap 
-is active pressing key `0-9` will "jump" back to the same keymap. That is 
-designated by the number `1` in the key binding. Only when the user presses 
-some other key we get out of this keymap. If the user presses `w` or `b`, we 
-run the command bound to the respective key. We get the repetition count by 
-slicing the all but last character from the `__keys` array and converting that 
+We give the keymap attached to key range `1-9` the `id` of 1. When that keymap
+is active pressing key `0-9` will "jump" back to the same keymap. That is
+designated by the number `1` in the key binding. Only when the user presses
+some other key we get out of this keymap. If the user presses `w` or `b`, we
+run the command bound to the respective key. We get the repetition count by
+slicing the all but last character from the `__keys` array and converting that
 to a number. The command key is the last item of the `__keys` array. We can
 access it more easily using the reversed `__rkeys` array. The item is first in
-that array. 
+that array.
 
-The picture below illustrates how keymap and command objects are stored in 
+The picture below illustrates how keymap and command objects are stored in
 memory.
 
 ![recursive keymap](images/recursive-keymap-example.png)
 
-It is also possible to jump to another keymap, which enables even more 
-complicated keyboard sequences. The only restriction is that you can only jump 
-to a key binding which is already defined. I.e. you cannot refer to an ID of a 
+It is also possible to jump to another keymap, which enables even more
+complicated keyboard sequences. The only restriction is that you can only jump
+to a key binding which is already defined. I.e. you cannot refer to an ID of a
 keymap that appears later in the configuration.
 
 > To better understand how keymaps work behind the scenes check the source
-> [documentation][10]. 
+> [documentation][10].
 
-Another new feature used in the example above is the optional `help` property 
-in the keymap. The contents of the property is shown in the status bar when the 
-keymap is active. It makes using long keyboard sequences easier by providing a 
+Another new feature used in the example above is the optional `help` property
+in the keymap. The contents of the property is shown in the status bar when the
+keymap is active. It makes using long keyboard sequences easier by providing a
 hint what keys you can press next.
 
 ### Keybindings in Selection/Visual Mode
 
 ModalEdit 2.0 adds a new configuration section called `selectbidings` that has
 the same structure as the `keybindings` section. With it you can now map keys
-that act as the lead key of a normal mode sequence to run a commands when 
-pressed in visual mode. 
+that act as the lead key of a normal mode sequence to run a commands when
+pressed in visual mode.
 
-For example, you might want the `d` key to be the leader key for sequence 
-"delete word" `dw` in normal mode, but in selection mode `d` should delete the selection 
-without expecting any following keys. Previously it was not possible to define 
-this behavior, but now you can do it with `selectbindings`. 
+For example, you might want the `d` key to be the leader key for sequence
+"delete word" `dw` in normal mode, but in selection mode `d` should delete the selection
+without expecting any following keys. Previously it was not possible to define
+this behavior, but now you can do it with `selectbindings`.
 
-`selectbindings` section is always checked first when ModalEdit looks for a 
-mapping for a keypress. If there is no binding defined in `selectbindings` 
+`selectbindings` section is always checked first when ModalEdit looks for a
+mapping for a keypress. If there is no binding defined in `selectbindings`
 then it checks the `keybindings` section. Note that you can still define normal
-mode commands that work differently when selection is active. You can use either 
-a conditional or parameterized command to check the `__selecting` flag, and 
+mode commands that work differently when selection is active. You can use either
+a conditional or parameterized command to check the `__selecting` flag, and
 perform a different action based on that.
 
 ### Debugging Keybindings
 
 If you are not sure that your bindings are correct, check the ModalEdit's
 output log. You can find it by opening **View - Output** and then choosing the
-**ModalEdit** from the drop-down menu. Errors in configuration will be reported 
-there. If your configuration is ok, you should see the following message. 
+**ModalEdit** from the drop-down menu. Errors in configuration will be reported
+there. If your configuration is ok, you should see the following message.
 
 ![output log](images/output-log.png)
 
 ### Changing Cursors
 
-You can set the cursor shape shown in each mode by changing the following 
-settings. 
+You can set the cursor shape shown in each mode by changing the following
+settings.
 
 | Setting               | Default       | Description
 | --------------------- | ------------- | -------------------------------------
@@ -355,7 +355,7 @@ along with the text color. Note that you can add icons in the text by using
 syntax `$(icon-name)` where `icon-name` is a valid name from the gallery of
 [built-in icons][15].
 
-The color of the status text is specified in HTML format, such as `#ffeeff`, 
+The color of the status text is specified in HTML format, such as `#ffeeff`,
 `cyan`, or `rgb(50, 50, 50)`. By default these colors are not defined, and thus
 they are same as the rest of text in the status bar.
 
@@ -372,31 +372,31 @@ they are same as the rest of text in the status bar.
 
 ### Start in Normal Mode
 
-If you want VS Code to be in insert mode when it starts, set the 
+If you want VS Code to be in insert mode when it starts, set the
 `startInNormalMode` setting to `false`. By default, editor is in normal mode
 when you open it.
 
 ### Example Configurations
 
-You can find example key bindings [here][7]. These are my own settings. The 
-cheat sheet for my keyboard layout is shown below. I have created it in 
-<http://www.keyboard-layout-editor.com/>. Please note that my keyboard layout 
+You can find example key bindings [here][7]. These are my own settings. The
+cheat sheet for my keyboard layout is shown below. I have created it in
+<http://www.keyboard-layout-editor.com/>. Please note that my keyboard layout
 is Finnish, so the non-alphanumeric keys might be in strange places.
 
 ![My keyboard layout](images/keyboard-layout.png)
 
-As you can see, I haven't followed Vim conventions but rather tailored the 
-keyboard layout according to my own preferences. I encourage you to do the same. 
+As you can see, I haven't followed Vim conventions but rather tailored the
+keyboard layout according to my own preferences. I encourage you to do the same.
 
 In general, you should not try to convert VS Code into a Vim clone. The editing
 philosophies of Vim and VS Code are quite dissimilar. Targets of Vim operations
-are defined with special range commands, whereas VS Code's commands operate on 
-selected text. For example, to delete a word in Vim, you first press `d` to 
-delete and then `w` for word. In VS Code you first select the word (with `W` or 
+are defined with special range commands, whereas VS Code's commands operate on
+selected text. For example, to delete a word in Vim, you first press `d` to
+delete and then `w` for word. In VS Code you first select the word (with `W` or
 `e` key in my configuration) then you delete the selection with `d` key.
 
-To better understand the difference, check out [Kakoune editor's documentation][8]. 
-ModalEdit extends VS Code with normal mode editing, so you have more or less 
+To better understand the difference, check out [Kakoune editor's documentation][8].
+ModalEdit extends VS Code with normal mode editing, so you have more or less
 the same capabilities as in Kakoune.
 
 ## Additional VS Code Commands
@@ -406,7 +406,7 @@ create more Vim-like workflow for searching and navigation.
 
 ### Switching between Modes
 
-Use the following commands to change the current editor mode. None of the 
+Use the following commands to change the current editor mode. None of the
 commands require any arguments.
 
 | Command                     | Description
@@ -421,32 +421,32 @@ commands require any arguments.
 
 ### Incremental Search
 
-The standard search functionality in VS Code is quite clunky as it opens a 
-dialog which takes you out of the editor. To achieve more fluid searching 
-experience ModalEdit provides incremental search commands that mimic Vim's 
+The standard search functionality in VS Code is quite clunky as it opens a
+dialog which takes you out of the editor. To achieve more fluid searching
+experience ModalEdit provides incremental search commands that mimic Vim's
 corresponding operations.
 
-> There are lot of new parameters in the `search` command that were added in 
-> version 2.0. Specifically, `typeAfter...` and `typeBefore...` arguments might 
-> seem odd at first glance. Please see the [change log](CHANGELOG.html) to 
+> There are lot of new parameters in the `search` command that were added in
+> version 2.0. Specifically, `typeAfter...` and `typeBefore...` arguments might
+> seem odd at first glance. Please see the [change log](CHANGELOG.html) to
 > understand the rationale why they are needed.
 
-#### `modaledit.search`  
+#### `modaledit.search`
 
 Starts incremental search. The cursor is changed to indicate that editor is in
 search mode. Normal mode commands are suppressed while incremental search is
-active. Just type the search string directly without leaving the editor. You 
-can see the searched string in the status bar as well as the search parameters. 
+active. Just type the search string directly without leaving the editor. You
+can see the searched string in the status bar as well as the search parameters.
 
 ![Searching](images/searching.gif)
 
-The command takes following arguments. All of them are optional. 
+The command takes following arguments. All of them are optional.
 
 | Argument                  | Type      | Default     | Description
 | ------------------------- | --------- | ----------- | ---------------------------------
 | `backwards`               | `boolean` | `false`     | Search backwards. Default is forwards
 | `caseSensitive`           | `boolean` | `false`     | Search is case-sensitive. Default is case-insensitive
-| `wrapAround`              | `boolean` | `false`     | Search wraps around to top/bottom depending on search direction. Default is off. 
+| `wrapAround`              | `boolean` | `false`     | Search wraps around to top/bottom depending on search direction. Default is off.
 | `acceptAfter`             | `number`  | `undefined` | Accept search automatically after _x_ characters has been entered. This helps implementing quick one or two character search operations.
 | `selectTillMatch`         | `boolean` | `false`     | Select the range from current position till the match instead of just the match. Useful with `acceptAfter` to quickly extend selection till the specified character(s).
 | `typeAfterAccept`         | `string`  | `undefined` | Allows to run normal mode commands through key bindings (see `modaledit.typeNormalKeys` command) after successful search. The argument can be used to enter insert mode, or clear selection after search, for example.
@@ -457,8 +457,8 @@ The command takes following arguments. All of them are optional.
 
 #### `modaledit.cancelSearch`
 
-Cancels the incremental search, returns the cursor to the starting position, 
-and switches back to normal mode. 
+Cancels the incremental search, returns the cursor to the starting position,
+and switches back to normal mode.
 
 #### `modaledit.deleteCharFromSearch`
 
@@ -479,14 +479,15 @@ search direction.
 
 To quickly jump inside documents ModalEdit provides two bookmark commands:
 
-- `modaledit.defineBookmark` stores the current position in a bookmark, and 
+- `modaledit.defineBookmark` stores the current position in a bookmark, and
 - `modaledit.goToBookmark` jumps to the given bookmark.
 - `modaledit.showBookmarks` shows the defined bookmarks in the command bar and
   allows jumping to them by selecting one.
 
-The first two commands take one argument which contains the bookmark name. It 
+The first two commands take one argument which contains the bookmark name. It
 can be any string (or number), so you can define unlimited number of bookmarks.
-If the argument is omitted, default value `0` is assumed. 
+If the argument is omitted, default value `0` is assumed.
+
 ```js
 {
     "command": "modaledit.defineBookmark",
@@ -498,13 +499,13 @@ If the argument is omitted, default value `0` is assumed.
 
 ### Quick Snippets
 
-Snippets come in handy when you need to insert boilerplate text. However, the 
-problem with snippets is that very seldom one bothers to create a new one. If a 
-snippet is used only a couple of times in a specific situation, the effort of 
-defining it nullifies the advantage. 
+Snippets come in handy when you need to insert boilerplate text. However, the
+problem with snippets is that very seldom one bothers to create a new one. If a
+snippet is used only a couple of times in a specific situation, the effort of
+defining it nullifies the advantage.
 
-With ModalEdit, you can create snippets quickly by selecting a region of text 
-and invoking command `modaledit.defineQuickSnippet`. You can assign the snippet 
+With ModalEdit, you can create snippets quickly by selecting a region of text
+and invoking command `modaledit.defineQuickSnippet`. You can assign the snippet
 to a register by specifying its index as an argument.
 ```js
 {
@@ -514,22 +515,22 @@ to a register by specifying its index as an argument.
     }
 }
 ```
-Use the `modaledit.insertQuickSnippet` command to insert the defined snippet at 
+Use the `modaledit.insertQuickSnippet` command to insert the defined snippet at
 the cursor position. It takes the same argument as `modaledit.defineQuickSnippet`.
 
-A snippet can have arguments or placeholders which you can fill in after 
-inserting it. These are written as `$1`, `$2`, ... inside the snippet. You can 
-quickly define the arguments with the `modaledit.fillSnippetArgs` command. First 
-multi-select all the arguments (by pressing `Alt` while selecting with a mouse), 
-then run the command. After that, select the snippet itself and run the 
+A snippet can have arguments or placeholders which you can fill in after
+inserting it. These are written as `$1`, `$2`, ... inside the snippet. You can
+quickly define the arguments with the `modaledit.fillSnippetArgs` command. First
+multi-select all the arguments (by pressing `Alt` while selecting with a mouse),
+then run the command. After that, select the snippet itself and run the
 `modaledit.defineQuickSnippet` command.
 
-In the following example key sequence `q - a` fills snippet arguments, 
-`q - w - 1` defines snippet in register 1, and `q - 1` inserts it. 
+In the following example key sequence `q - a` fills snippet arguments,
+`q - w - 1` defines snippet in register 1, and `q - 1` inserts it.
 
 ![Quick snippet](images/quick-snippet.gif)
 
-It is usually a good idea to run `editor.action.formatDocument` after inserting 
+It is usually a good idea to run `editor.action.formatDocument` after inserting
 a snippet to clean up whitespace. You can do this automatically adding it
 to the command sequence.
 ```js
@@ -548,13 +549,13 @@ to the command sequence.
 
 ### Invoking Key Bindings
 
-The new command `modaledit.typeNormalKeys` invokes commands through key 
-bindings. Calling this command with a key sequence has the same effect as 
+The new command `modaledit.typeNormalKeys` invokes commands through key
+bindings. Calling this command with a key sequence has the same effect as
 pressing the keys in normal mode. This allows you to treat key bindings as
 subroutines that can be called using this command.
 
-The command has one argument `keys` which contains the key sequence as string. 
-Assuming that keys `k` and `u` are bound to some commands, the following 
+The command has one argument `keys` which contains the key sequence as string.
+Assuming that keys `k` and `u` are bound to some commands, the following
 example runs them both one after another.
 ```js
 {
@@ -567,20 +568,20 @@ example runs them both one after another.
 
 ### Selecting Text Between Delimiters
 
-The `modaledit.selectBetween` command helps implement advanced selection 
-operations. The command takes as arguments two strings/regular expressions that 
-delimit the text to be selected. Both of them are optional, but in order for the 
-command to do anything one of them needs to be defined. If the `from` argument 
-is missing, the selection goes from the cursor position forwards to the `to` 
-string. If the `to` is missing the selection goes backwards till the `from` 
+The `modaledit.selectBetween` command helps implement advanced selection
+operations. The command takes as arguments two strings/regular expressions that
+delimit the text to be selected. Both of them are optional, but in order for the
+command to do anything one of them needs to be defined. If the `from` argument
+is missing, the selection goes from the cursor position forwards to the `to`
+string. If the `to` is missing the selection goes backwards till the `from`
 string. In addition to these parameters, the command has four flags:
 
 - If the `regex` flag is on, `from` and `to` strings are treated as regular
   expressions in the search.
-- The `inclusive` flag tells if the delimiter strings are included in the 
-  selection or not. By default the delimiter strings are not part of the 
+- The `inclusive` flag tells if the delimiter strings are included in the
+  selection or not. By default the delimiter strings are not part of the
   selection.
-- The `caseSensitive` flag makes the search case-sensitive. When this flag is 
+- The `caseSensitive` flag makes the search case-sensitive. When this flag is
   missing or false the search is case-insensitive.
 - By default the search scope is the current line. If you want search inside
   the whole document, set the `docScope` flag.
@@ -590,8 +591,8 @@ advanced examples check the [tutorial][9].
 ```js
 {
     "command": "modaledit.selectBetween",
-    "args": { 
-        "from": "(", 
+    "args": {
+        "from": "(",
         "to": ")"
     }
 }
@@ -599,8 +600,8 @@ advanced examples check the [tutorial][9].
 
 ### Repeat Last Change
 
-`modaledit.repeatLastChange` command repeats the last command (sequence) that 
-caused text in the editor to change. It corresponds to the [dot `.` command][13] 
+`modaledit.repeatLastChange` command repeats the last command (sequence) that
+caused text in the editor to change. It corresponds to the [dot `.` command][13]
 in Vim. The command takes no arguments.
 
 ### Importing Presets
@@ -610,10 +611,10 @@ keybindings from a file and copies them to the global `settings.json` file. It
 overrides existing keybindings, so back them up somewhere before running the
 command, if you want to preserve them.
 
-In 2.0, also Vim keybindings were added as built-in presets. You can learn more 
-about Vim bindings [here][14]. Built-in presets are located under the `presets` 
-folder under the extension installation folder. The command scans and lists all 
-the files there. It also provides an option to browse for any other file you 
+In 2.0, also Vim keybindings were added as built-in presets. You can learn more
+about Vim bindings [here][14]. Built-in presets are located under the `presets`
+folder under the extension installation folder. The command scans and lists all
+the files there. It also provides an option to browse for any other file you
 want to import.
 
 Presets are stored either in a JSON or JavaScript file. In either case, the
@@ -631,23 +632,23 @@ be the expression that the whole script evaluates to.
 
 ## Acknowledgements
 
-I was using the [Simple Vim][3] extension for a long time, but was never fully 
-happy with it. It shares the idea of being a simple extension reusing VS Code's 
+I was using the [Simple Vim][3] extension for a long time, but was never fully
+happy with it. It shares the idea of being a simple extension reusing VS Code's
 functionality, but it is sorely lacking in configurability. If you don't like
-its default key mappings, you are out of luck. 
+its default key mappings, you are out of luck.
 
 Then I found extension called [Vimspired][4] which has a really great idea for
-implementing modal editing: just add a section in the `settings.json` which 
-contains the keymap for normal mode. This allows you to mimic Vim behavior, if 
-you wish to do so, or take a completely different approach. For example, don't 
-use `h`, `j`, `k`, `l` keys to move the cursor but `w`, `a`, `s`, `d` keys 
-instead.   
+implementing modal editing: just add a section in the `settings.json` which
+contains the keymap for normal mode. This allows you to mimic Vim behavior, if
+you wish to do so, or take a completely different approach. For example, don't
+use `h`, `j`, `k`, `l` keys to move the cursor but `w`, `a`, `s`, `d` keys
+instead.
 
-I really like Vimspired, but still wanted to change some of its core behavior 
-and add many additional features. I didn't want to harass the author with 
+I really like Vimspired, but still wanted to change some of its core behavior
+and add many additional features. I didn't want to harass the author with
 extensive pull requests, so I decided to implement my own take of the theme. I
 shameleslly copied the core parts of Vimspired and then changed them beyond
-recognition. Anyway, credit goes to [Brian Malehorn][5] for coming up with the 
+recognition. Anyway, credit goes to [Brian Malehorn][5] for coming up with the
 great idea and helping me jump start my project.
 
 [1]: https://unix.stackexchange.com/questions/57705/modeless-vs-modal-editors

--- a/README.md
+++ b/README.md
@@ -415,7 +415,9 @@ commands require any arguments.
 | `modaledit.enterNormal`     | Switches to normal mode
 | `modaledit.enterInsert`     | Switches to insert mode
 | `modaledit.toggleSelection` | Toggles selection mode on or off. Selection mode is implicitly on whenever editor has text selected
+| `modaledit.enableSelection` | Turn selection mode on.
 | `modaledit.cancelSelection` | Cancel selection mode and clear selection.
+| `modaledit.resetSelection`  | Cancel selection mode and clear selection, but keep multiple cursors
 
 ### Incremental Search
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -181,6 +181,7 @@ const toggleId = "modaledit.toggle"
 const enterNormalId = "modaledit.enterNormal"
 const enterInsertId = "modaledit.enterInsert"
 const toggleSelectionId = "modaledit.toggleSelection"
+const enableSelectionId = "modaledit.enableSelection"
 const cancelSelectionId = "modaledit.cancelSelection"
 const resetSelectionId = "modaledit.resetSelection"
 const searchId = "modaledit.search"
@@ -210,6 +211,7 @@ export function register(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(enterNormalId, enterNormal),
         vscode.commands.registerCommand(enterInsertId, enterInsert),
         vscode.commands.registerCommand(toggleSelectionId, toggleSelection),
+        vscode.commands.registerCommand(enableSelectionId, enableSelection),
         vscode.commands.registerCommand(cancelSelectionId, cancelSelection),
         vscode.commands.registerCommand(resetSelectionId, resetSelection),
         vscode.commands.registerCommand(searchId, search),
@@ -430,6 +432,15 @@ async function toggleSelection(): Promise<void> {
     selecting = !oldSelecting
     updateCursorAndStatusBar(vscode.window.activeTextEditor)
 }
+
+/**
+ * `modaledit.enableSelection` sets the selecting to true.
+ */
+function enableSelection() {
+    selecting = true;
+    updateStatusBar(vscode.window.activeTextEditor)
+}
+
 /**
  * The following helper function actually determines, if a selection is active.
  * It checks not only the `selecting` flag but also if there is any text 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -182,6 +182,7 @@ const enterNormalId = "modaledit.enterNormal"
 const enterInsertId = "modaledit.enterInsert"
 const toggleSelectionId = "modaledit.toggleSelection"
 const cancelSelectionId = "modaledit.cancelSelection"
+const resetSelectionId = "modaledit.resetSelection"
 const searchId = "modaledit.search"
 const cancelSearchId = "modaledit.cancelSearch"
 const deleteCharFromSearchId = "modaledit.deleteCharFromSearch"
@@ -210,6 +211,7 @@ export function register(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(enterInsertId, enterInsert),
         vscode.commands.registerCommand(toggleSelectionId, toggleSelection),
         vscode.commands.registerCommand(cancelSelectionId, cancelSelection),
+        vscode.commands.registerCommand(resetSelectionId, resetSelection),
         vscode.commands.registerCommand(searchId, search),
         vscode.commands.registerCommand(cancelSearchId, cancelSearch),
         vscode.commands.registerCommand(deleteCharFromSearchId,
@@ -399,6 +401,23 @@ async function cancelSelection(): Promise<void> {
         updateCursorAndStatusBar(vscode.window.activeTextEditor)
     }
 }
+
+/**
+ * `modaledit.resetSelection`, like `modaledit.cancelSelect` sets selecting to
+ * false sets the anchor === active selection position. Unlike
+ * `modaledit.cancelSelect` it does not clear multiple selections
+ */
+function resetSelection() {
+    let editor = vscode.window.activeTextEditor
+    if(editor){
+        editor.selections = editor.selections.map((sel: vscode.Selection) => {
+            return new vscode.Selection(sel.active,sel.active);
+        })
+    }
+    selecting = false
+    updateStatusBar(vscode.window.activeTextEditor)
+}
+
 /**
  * `modaledit.toggleSelection` toggles the selection mode on and off. It sets
  * the selection mode flag and updates the status bar, but also clears the 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 /**
  * # Commands and State
- * 
+ *
  * This module implements the new commands provided by ModalEdit. It also stores
  * the extension state; which mode we are in, search parameters, bookmarks,
  * quick snippets, etc.
@@ -12,13 +12,13 @@ import { TextDecoder } from 'util'
 //#endregion
 /**
  * ## Command Arguments
- * 
- * Most commands provided by ModalEdit take arguments. Since command arguments 
+ *
+ * Most commands provided by ModalEdit take arguments. Since command arguments
  * are stored in objects by-design, we define them as interfaces.
- * 
+ *
  * ### Search Arguments
- * 
- * Search arguments are documented in the 
+ *
+ * Search arguments are documented in the
  * [README](../README.html#code-modaledit-search-code).
  */
 interface SearchArgs {
@@ -35,9 +35,9 @@ interface SearchArgs {
 }
 /**
  * ### Bookmark Arguments
- * 
- * [Bookmark](../README.html#bookmarks) ID is a user specified string label. 
- * Actual positions are stored in an object that conforms to the `Bookmark` 
+ *
+ * [Bookmark](../README.html#bookmarks) ID is a user specified string label.
+ * Actual positions are stored in an object that conforms to the `Bookmark`
  * interface in the `bookmarks` dictionary.
  */
 interface BookmarkArgs {
@@ -60,7 +60,7 @@ class Bookmark implements vscode.QuickPickItem {
 }
 /**
  * ### Quick Snippet Arguments
- * 
+ *
  * [Quick snippets](../README.html#quick-snippets) are also stored in an array.
  * So their IDs are indexes as well.
  */
@@ -69,8 +69,8 @@ interface QuickSnippetArgs {
 }
 /**
  * ### Type Normal Keys Arguments
- * 
- * The [`typeNormalKeys` command](../README.html#invoking-key-bindings) gets the 
+ *
+ * The [`typeNormalKeys` command](../README.html#invoking-key-bindings) gets the
  * entered keys as a string.
  */
 interface TypeNormalKeysArgs {
@@ -78,22 +78,22 @@ interface TypeNormalKeysArgs {
 }
 /**
  * ### Select Between Arguments
- * 
- * The `selectBetween` command takes as arguments the strings/regular 
- * expressions which delimit the text to be selected. Both of them are optional, 
- * but in order for the command to do anything one of them needs to be defined. 
- * If the `from` argument is missing, the selection goes from the cursor 
- * position forwards to the `to` string. If the `to` is missing the selection 
- * goes backwards till the `from` string. 
- * 
+ *
+ * The `selectBetween` command takes as arguments the strings/regular
+ * expressions which delimit the text to be selected. Both of them are optional,
+ * but in order for the command to do anything one of them needs to be defined.
+ * If the `from` argument is missing, the selection goes from the cursor
+ * position forwards to the `to` string. If the `to` is missing the selection
+ * goes backwards till the `from` string.
+ *
  * If the `regex` flag is on, `from` and `to` strings are treated as regular
  * expressions in the search.
- * 
- * The `inclusive` flag tells if the delimiter strings are included in the 
- * selection or not. By default the delimiter strings are not part of the 
- * selection. Last, the `caseSensitive` flag makes the search case sensitive. 
+ *
+ * The `inclusive` flag tells if the delimiter strings are included in the
+ * selection or not. By default the delimiter strings are not part of the
+ * selection. Last, the `caseSensitive` flag makes the search case sensitive.
  * When this flag is missing or false the search is case insensitive.
- * 
+ *
  * By default the search scope is the current line. If you want search inside
  * the whole document, set the `docScope` flag.
  */
@@ -107,22 +107,22 @@ interface SelectBetweenArgs {
 }
 /**
  * ## State Variables
- * 
+ *
  * The enabler for modal editing is the `type` event that VS Code provides. It
- * reroutes the user's key presses to our extension. We store the handler to 
+ * reroutes the user's key presses to our extension. We store the handler to
  * this event in the `typeSubscription` variable.
  */
 let typeSubscription: vscode.Disposable | undefined
 /**
- * We add two items in the status bar that show the current mode. The main 
- * status bar shows the current state we are in. The secondary status bar shows 
- * additional info such as keys that have been pressed so far and any help 
- * strings defined in key bindings.  
+ * We add two items in the status bar that show the current mode. The main
+ * status bar shows the current state we are in. The secondary status bar shows
+ * additional info such as keys that have been pressed so far and any help
+ * strings defined in key bindings.
  */
 let mainStatusBar: vscode.StatusBarItem
 let secondaryStatusBar: vscode.StatusBarItem
 /**
- * This is the main mode flag that tells if we are in normal mode or insert 
+ * This is the main mode flag that tells if we are in normal mode or insert
  * mode.
  */
 let normalMode = true
@@ -131,8 +131,8 @@ let normalMode = true
  * it is not the only indicator that tells whether a selection is active.
  */
 let selecting = false
-/** 
- * The `searching` flag tells if `modaledit.search` command is in operation. 
+/**
+ * The `searching` flag tells if `modaledit.search` command is in operation.
  */
 let searching = false
 /**
@@ -142,7 +142,7 @@ let searchString: string
 let searchStartSelections: vscode.Selection[]
 let searchInfo: string | null = null
 /**
- * Current search parameters. 
+ * Current search parameters.
  */
 let searchBackwards = false
 let searchCaseSensitive = false
@@ -174,7 +174,7 @@ let lastKeySequence: string[] = []
 let lastChange: string[] = []
 /**
  * ## Command Names
- * 
+ *
  * Since command names are easy to misspell, we define them as constants.
  */
 const toggleId = "modaledit.toggle"
@@ -201,7 +201,7 @@ const repeatLastChangeId = "modaledit.repeatLastChange"
 const importPresetsId = "modaledit.importPresets"
 /**
  * ## Registering Commands
- * 
+ *
  * The commands are registered when the extension is activated (main entry point
  * calls this function). We also create the status bar item.
  */
@@ -239,10 +239,10 @@ export function register(context: vscode.ExtensionContext) {
 }
 /**
  * ## Keyboard Event Handler
- * 
- * When the user types in normal mode, `onType` handler gets each typed 
+ *
+ * When the user types in normal mode, `onType` handler gets each typed
  * character one at a time. It calls the `runActionForKey` subroutine to invoke
- * the action bound to the typed key. In addition, it updates the state 
+ * the action bound to the typed key. In addition, it updates the state
  * variables needed by the `repeatLastChange` command and the status bar.
  */
 async function onType(event: { text: string }) {
@@ -259,18 +259,18 @@ async function onType(event: { text: string }) {
 }
 /**
  * Whenever text changes in an active editor, we set a flag. This flag is
- * examined in the `onType` handler above, and the `lastChange` variable is set 
+ * examined in the `onType` handler above, and the `lastChange` variable is set
  * to indicate that the last command that changed editor text.
  */
 export function onTextChanged() {
     textChanged = true
 }
 /**
- * This helper function just calls the `handleKey` function in the `actions` 
+ * This helper function just calls the `handleKey` function in the `actions`
  * module. It checks if we have an active selection or search mode on, and
- * passes that information to the function. `handleKey` returns `true` if the 
- * key actually invoked a command, or `false` if it was a part of incomplete 
- * key sequence that did not (yet) cause any commands to run. This information 
+ * passes that information to the function. `handleKey` returns `true` if the
+ * key actually invoked a command, or `false` if it was a part of incomplete
+ * key sequence that did not (yet) cause any commands to run. This information
  * is needed to decide whether the `lastKeySequence` variable is updated.
  */
 async function runActionForKey(key: string): Promise<boolean> {
@@ -278,7 +278,7 @@ async function runActionForKey(key: string): Promise<boolean> {
 }
 /**
  * ## Mode Switching  Commands
- * 
+ *
  * `toggle` switches between normal and insert mode.
  */
 export function toggle() {
@@ -289,11 +289,11 @@ export function toggle() {
 }
 /**
  * When entering normal mode, we:
- * 
+ *
  * 1. cancel the search, if it is on,
  * 2. subscribe to the `type` event,
  * 3. handle the rest of the mode setup with `setNormalMode` function, and
- * 4. clear the selection. 
+ * 4. clear the selection.
  */
 export function enterNormal() {
     cancelSearch()
@@ -304,13 +304,13 @@ export function enterNormal() {
 }
 /**
  * Conversely, when entering insert mode, we:
- * 
+ *
  * 1. cancel the search, if it is on (yes, you can use it in insert mode, too),
  * 2. unsubscribe to the `type` event,
  * 3. handle the rest of the mode setup with `setNormalMode` function.
- * 
+ *
  * Note that we specifically don't clear the selection. This allows the user
- * to easily surround selected text with hyphens `'`, parenthesis `(` and `)`, 
+ * to easily surround selected text with hyphens `'`, parenthesis `(` and `)`,
  * brackets `[` and `]`, etc.
  */
 export function enterInsert() {
@@ -323,8 +323,8 @@ export function enterInsert() {
 }
 /**
  * The rest of the state handling is delegated to subroutines that do specific
- * things. `setNormalMode` sets or resets the VS Code `modaledit.normal` context. 
- * This can be used in "standard" key bindings. Then it sets the `normalMode` 
+ * things. `setNormalMode` sets or resets the VS Code `modaledit.normal` context.
+ * This can be used in "standard" key bindings. Then it sets the `normalMode`
  * variable and calls the next subroutine which updates cursor and status bar.
  */
 async function setNormalMode(value: boolean): Promise<void> {
@@ -338,8 +338,8 @@ async function setNormalMode(value: boolean): Promise<void> {
 }
 /**
  * This function updates the cursor shape and status bar according to editor
- * state. It indicates when selection is active or search mode is on. If 
- * so, it shows the search parameters. If no editor is active, we hide the 
+ * state. It indicates when selection is active or search mode is on. If
+ * so, it shows the search parameters. If no editor is active, we hide the
  * status bar items.
  */
 export function updateCursorAndStatusBar(editor: vscode.TextEditor | undefined,
@@ -390,11 +390,11 @@ export function updateCursorAndStatusBar(editor: vscode.TextEditor | undefined,
 }
 /**
  * ## Selection Commands
- * 
+ *
  * `modaledit.cancelSelection` command clears the selection using ths standard
  * `cancelSelection` command, but also sets the `selecting` flag to false, and
  * updates the status bar. It is advisable to use this command instead of the
- * standard version to keep the state in sync. 
+ * standard version to keep the state in sync.
  */
 async function cancelSelection(): Promise<void> {
     if (selecting) {
@@ -406,7 +406,7 @@ async function cancelSelection(): Promise<void> {
 
 /**
  * `modaledit.resetSelection`, like `modaledit.cancelSelect` sets selecting to
- * false sets the anchor === active selection position. Unlike
+ * false and sets the anchor === active selection position. Unlike
  * `modaledit.cancelSelect` it does not clear multiple selections
  */
 function resetSelection() {
@@ -417,12 +417,12 @@ function resetSelection() {
         })
     }
     selecting = false
-    updateStatusBar(vscode.window.activeTextEditor)
+    updateCursorAndStatusBar(vscode.window.activeTextEditor)
 }
 
 /**
  * `modaledit.toggleSelection` toggles the selection mode on and off. It sets
- * the selection mode flag and updates the status bar, but also clears the 
+ * the selection mode flag and updates the status bar, but also clears the
  * selection.
  */
 async function toggleSelection(): Promise<void> {
@@ -438,12 +438,12 @@ async function toggleSelection(): Promise<void> {
  */
 function enableSelection() {
     selecting = true;
-    updateStatusBar(vscode.window.activeTextEditor)
+    updateCursorAndStatusBar(vscode.window.activeTextEditor)
 }
 
 /**
  * The following helper function actually determines, if a selection is active.
- * It checks not only the `selecting` flag but also if there is any text 
+ * It checks not only the `selecting` flag but also if there is any text
  * selected in the active editor.
  */
 function isSelecting(): boolean {
@@ -456,7 +456,7 @@ function isSelecting(): boolean {
 /**
  * Function that sets the selecting flag off. This function is called from one
  * event. The flag is resetted when the active editor changes. The function that
- * updates the status bar sets the flag on again, if there are any active 
+ * updates the status bar sets the flag on again, if there are any active
  * selections.
  */
 export function resetSelecting() {
@@ -464,12 +464,12 @@ export function resetSelecting() {
 }
 /**
  * ## Search Commands
- * 
+ *
  * Incremental search is by far the most complicated part of this extension.
  * Searching overrides both normal and insert modes, and captures the keyboard
- * until it is done. The following subroutine sets the associated state 
+ * until it is done. The following subroutine sets the associated state
  * variable, the VS Code `modaledit.searching` context, and the status bar.
- * Since search mode also puts the editor implicitly in the normal mode, we 
+ * Since search mode also puts the editor implicitly in the normal mode, we
  * need to check what was the state when we initiated the search. If we were in
  * insert mode, we return also there.
  */
@@ -497,7 +497,7 @@ async function search(args: SearchArgs | string): Promise<void> {
         /**
          * If we get an object as argument, we start a new search. We switch
          * to normal mode, if necessary. Then we initialize the search string
-         * to empty, and store the current selections in the 
+         * to empty, and store the current selections in the
          * `searchStartSelections` array. We need an array as the command also
          * works with multiple cursors. Finally we store the search arguments
          * in the module level variables.
@@ -538,16 +538,16 @@ async function search(args: SearchArgs | string): Promise<void> {
     }
 }
 /**
- * The actual search functionality is located in this helper function. It is 
- * used by the actual search command plus the commands that jump to next and 
+ * The actual search functionality is located in this helper function. It is
+ * used by the actual search command plus the commands that jump to next and
  * previous match.
- * 
- * The search starts from positions specified by the `selections` argument. If 
- * there are multilple selections (cursors) active, multiple searches are 
+ *
+ * The search starts from positions specified by the `selections` argument. If
+ * there are multilple selections (cursors) active, multiple searches are
  * performed. Each cursor location is considered separately, and the next match
  * from that position is selected. The function does *not* make sure that found
- * matches are unique. In case the matches overlap, the number of selections 
- * will decrease. 
+ * matches are unique. In case the matches overlap, the number of selections
+ * will decrease.
  */
 function highlightMatches(editor: vscode.TextEditor,
     selections: vscode.Selection[]) {
@@ -566,7 +566,7 @@ function highlightMatches(editor: vscode.TextEditor,
         let docText = searchCaseSensitive ?
             doc.getText() : doc.getText().toLowerCase()
         /**
-         * Next we determine the search target. It is also transformed to 
+         * Next we determine the search target. It is also transformed to
          * lower case, if search is case-insensitive.
          */
         let target = searchCaseSensitive ?
@@ -575,11 +575,11 @@ function highlightMatches(editor: vscode.TextEditor,
             /**
              * This is the actual search that is performed for each cursor
              * position. The lambda function returns a new selection for each
-             * active cursor. 
+             * active cursor.
              */
             let startOffs = doc.offsetAt(sel.active)
-            /** 
-             * Depending on the search direction we find either the 
+            /**
+             * Depending on the search direction we find either the
              * first or the last match from the start offset.
              */
             let offs = searchBackwards ?
@@ -606,7 +606,7 @@ function highlightMatches(editor: vscode.TextEditor,
                     limit(!searchBackwards)}`
             }
             /**
-             * If search was successful, we return a new selection to highlight 
+             * If search was successful, we return a new selection to highlight
              * it. First, we find the start and end position of the match.
              */
             let len = searchString.length
@@ -631,8 +631,8 @@ function highlightMatches(editor: vscode.TextEditor,
 }
 /**
  * ### Accepting Search
- * 
- * Accepting the search resets the mode variables. Additionally, if 
+ *
+ * Accepting the search resets the mode variables. Additionally, if
  * `typeAfterAccept` argument is set we run the given normal mode commands.
  */
 async function acceptSearch() {
@@ -642,7 +642,7 @@ async function acceptSearch() {
 }
 /**
  * ### Canceling Search
- * 
+ *
  * Canceling search just resets state, and moves the cursor back to the starting
  * position.
  */
@@ -658,7 +658,7 @@ async function cancelSearch(): Promise<void> {
 }
 /**
  * ### Modifying Search String
- * 
+ *
  * Since we cannot capture the backspace character in normal mode, we have to
  * hook it some other way. We define a command `modaledit.deleteCharFromSearch`
  * which deletes the last character from the search string. This command can
@@ -686,13 +686,13 @@ function deleteCharFromSearch() {
 }
 /**
  * ### Finding Previous and Next Match
- * 
- * Using the `highlightMatches` function finding next and previous match is a 
+ *
+ * Using the `highlightMatches` function finding next and previous match is a
  * relatively simple task. We basically just restart the search from
- * the current cursor position(s). 
- * 
- * We also check whether the search parameters include `typeBeforeNextMatch` or 
- * `typeAfterNextMatch` argument. If so, we invoke the user-specified commands 
+ * the current cursor position(s).
+ *
+ * We also check whether the search parameters include `typeBeforeNextMatch` or
+ * `typeAfterNextMatch` argument. If so, we invoke the user-specified commands
  * before and/or after we jump to the next match.
  */
 async function nextMatch(): Promise<void> {
@@ -723,7 +723,7 @@ async function previousMatch(): Promise<void> {
 }
 /**
  * ## Bookmarks
- * 
+ *
  * Defining a bookmark is simple. We just store the cursor location and file in
  * a `Bookmark` object, and store it in the `bookmarks` array.
  */
@@ -777,7 +777,7 @@ function changeSelection(editor: vscode.TextEditor, anchor: vscode.Position,
 }
 /**
  * ## Quick Snippets
- * 
+ *
  * Supporting quick snippets is also a pleasantly simple job. First we implement
  * the `modaledit.fillSnippetArgs` command, which replaces (multi-)selection
  * ranges with `$1`, `$2`, ...
@@ -802,7 +802,7 @@ function defineQuickSnippet(args?: QuickSnippetArgs) {
             editor.document.getText(editor.selection)
 }
 /**
- * Inserting a snippet is done as easily with the built-in command. We enter 
+ * Inserting a snippet is done as easily with the built-in command. We enter
  * insert mode automatically before snippet is expanded.
  */
 async function insertQuickSnippet(args?: QuickSnippetArgs): Promise<void> {
@@ -816,8 +816,8 @@ async function insertQuickSnippet(args?: QuickSnippetArgs): Promise<void> {
 }
 /**
  * ## Invoking Commands via Key Bindings
- * 
- * The last command runs normal mode commands throught their key bindings. 
+ *
+ * The last command runs normal mode commands throught their key bindings.
  * Implementing that is as easy as calling the keyboard handler.
  */
 async function typeNormalKeys(args: TypeNormalKeysArgs): Promise<void> {
@@ -828,10 +828,10 @@ async function typeNormalKeys(args: TypeNormalKeysArgs): Promise<void> {
 }
 /**
  * ## Advanced Selection Command
- * 
+ *
  * For selecting ranges of text between two characters (inside parenthesis, for
  * example) we add the `modaledit.selectBetween` command. See the
- * [instructions](../README.html#selecting-text-between-delimiters) for the list 
+ * [instructions](../README.html#selecting-text-between-delimiters) for the list
  * of parameters this command provides.
  */
 function selectBetween(args: SelectBetweenArgs) {
@@ -842,14 +842,14 @@ function selectBetween(args: SelectBetweenArgs) {
         throw Error(`${selectBetweenId}: Invalid args: ${JSON.stringify(args)}`)
     let doc = editor.document
     /**
-     * Get position of cursor and anchor. These positions might be in "reverse" 
-     * order (cursor lies before anchor), so we need to sort them into `lowPos` 
-     * and `highPos` variables and corresponding offset variables. These are 
-     * used to determine the search range later on. 
-     * 
-     * Since `to` or `from` parameter might be missing, we initialize the 
-     * `fromOffs` and `toOffs` variables to low and high offsets. They delimit 
-     * the range to be selected at the end.  
+     * Get position of cursor and anchor. These positions might be in "reverse"
+     * order (cursor lies before anchor), so we need to sort them into `lowPos`
+     * and `highPos` variables and corresponding offset variables. These are
+     * used to determine the search range later on.
+     *
+     * Since `to` or `from` parameter might be missing, we initialize the
+     * `fromOffs` and `toOffs` variables to low and high offsets. They delimit
+     * the range to be selected at the end.
      */
     let cursorPos = editor.selection.active
     let anchorPos = editor.selection.anchor
@@ -864,8 +864,8 @@ function selectBetween(args: SelectBetweenArgs) {
      * offset and `endOffs` the end. Depending on the specified scope these
      * variables are either set to start/end of the current line or the whole
      * document.
-     * 
-     * In the actual search, we have two main branches: one for the case when 
+     *
+     * In the actual search, we have two main branches: one for the case when
      * regex search is used and another for the normal text search.
      */
     let startPos = new vscode.Position(args.docScope ? 0 : lowPos.line, 0)
@@ -876,9 +876,9 @@ function selectBetween(args: SelectBetweenArgs) {
     if (args.regex) {
         if (args.from) {
             /**
-             * This branch searches for regex in the `from` parameter starting 
-             * from `startPos` continuing until `lowPos`. We need to find the 
-             * last occurrence of the regex, so we have to add a global modifier 
+             * This branch searches for regex in the `from` parameter starting
+             * from `startPos` continuing until `lowPos`. We need to find the
+             * last occurrence of the regex, so we have to add a global modifier
              * `g` and iterate through all the matches. In case there are no
              * matches `fromOffs` gets the same offset as `startOffs` meaning
              * that the selection will extend to the start of the search scope.
@@ -932,7 +932,7 @@ function selectBetween(args: SelectBetweenArgs) {
         }
     }
     if (cursorPos.isAfterOrEqual(anchorPos))
-        /** 
+        /**
          * The last thing to do is to select the range from `fromOffs` to
          * `toOffs`. We want to preserve the direction of the selection. If
          * it was reserved when this command was called, we flip the variables.
@@ -943,11 +943,11 @@ function selectBetween(args: SelectBetweenArgs) {
 }
 /**
  * ## Repeat Last Change Command
- * 
- * The `repeatLastChange` command runs the key sequence stored in `lastChange` 
- * variable. Since the command inevitably causes text in the editor to change 
- * (which causes the `textChanged` flag to go high), it has to reset the current 
- * key sequence to prevent the `lastChange` variable from being overwritten next 
+ *
+ * The `repeatLastChange` command runs the key sequence stored in `lastChange`
+ * variable. Since the command inevitably causes text in the editor to change
+ * (which causes the `textChanged` flag to go high), it has to reset the current
+ * key sequence to prevent the `lastChange` variable from being overwritten next
  * time the user presses a key.
  */
 async function repeatLastChange(): Promise<void> {
@@ -957,19 +957,19 @@ async function repeatLastChange(): Promise<void> {
 }
 /**
  * ## Use Preset Keybindings
- * 
+ *
  * This command will overwrite to `keybindings` and `selectbindings` settings
  * with presets. The presets are stored under the subdirectory named `presets`.
- * Command scans the directory and shows all the files in a pick list. 
+ * Command scans the directory and shows all the files in a pick list.
  * Alternatively the user can browse for other file that he/she has anywhere
- * in the file system. If the user selects a file, its contents will replace 
+ * in the file system. If the user selects a file, its contents will replace
  * the key binding in the global `settings.json` file.
- * 
+ *
  * The presets can be defined as JSON or JavaScript. The code checks the file
- * extension and surrounds JSON with parenthesis. Then it can evaluate the 
- * contents of the file as JavaScript. This allows to use non-standard JSON 
- * files that include comments. Or, if the user likes to define the whole 
- * shebang in code, he/she just has to make sure that the code evaluates to an 
+ * extension and surrounds JSON with parenthesis. Then it can evaluate the
+ * contents of the file as JavaScript. This allows to use non-standard JSON
+ * files that include comments. Or, if the user likes to define the whole
+ * shebang in code, he/she just has to make sure that the code evaluates to an
  * object that has `keybindings` and/or `selectbindings` properties.
  */
 async function importPresets() {


### PR DESCRIPTION
Hi there! Thanks again for your great extension.

I have been using your new updates on master and noticed that you are missing two *small* features that are useful when I am working with multiple cursors and various selection related tasks in my own configuration of modaledit. 

The problem these are trying to solve is that, in many cases, you don't want switching between selection modes to remove multiple cursors, which the current version doesn't allow for.

This adds two small commands:

- `enableSelection`: Turns on the selection mode if it is off, has no effect otherwise.
- `resetSelection`: Shrinks the range of all selections, keeping selection mode on.

There may also be a use for `disableSelection` which would call `resetSelection` and change the selection mode to off, but in my current configuration I haven't had a need for it.

I'm not sold on the exact names for these commands. I could see a number of other options.

This again has some changes to whitespace that VSCode automatically does for me, which I've tried to separate out in case you don't want that.