### PR TITLE
Move warning message to status bar + allow mouse click to enter input mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,10 @@
 					"type": "string",
 					"description": "Color of the status bar mode text when selection is active in normal mode (in HTML format)."
 				},
+				"modaledit.errorStatusColor": {
+					"type": "string",
+					"description": "Color of the secondary status bar text when showing an error"
+				},
 				"modaledit.startInNormalMode": {
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -250,6 +250,11 @@
 					"type": "string",
 					"description": "Color of the secondary status bar text when showing an error"
 				},
+				"modaledit.mouseSelectionEntersInputMode": {
+					"type": "boolean",
+					"default": true,
+					"description": "Does mouse selection put you in insert mode?"
+				},
 				"modaledit.startInNormalMode": {
 					"type": "boolean",
 					"default": true,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -101,6 +101,10 @@ let normalStatusColor: string | undefined
 let searchStatusColor: string | undefined
 let selectStatusColor: string | undefined
 /**
+ * Error status color
+ */
+let errorStatusColor: string | undefined
+/**
  * Another thing you can set in config, is whether ModalEdit starts in normal
  * mode. 
  */
@@ -159,8 +163,18 @@ export function getSelectStyles():
     return [ selectCursorStyle, selectStatusText, selectStatusColor ]
 }
 
+export function getErrorStatusColor(): string | undefined {
+    return errorStatusColor
+}
+
 export function getStartInNormalMode(): boolean {
     return startInNormalMode
+}
+/**
+ * Force clear current keymap 
+ */
+export function clearKeys() {
+    currentKeymap = null;
 }
 /**
  * You can also set the last command from outside the module.
@@ -214,6 +228,7 @@ export function updateFromConfig(): void {
     normalStatusColor = config.get("normalStatusColor") || undefined
     searchStatusColor = config.get("searchStatusColor") || undefined
     selectStatusColor = config.get("selectStatusColor") || undefined
+    errorStatusColor = config.get("errorStatusColor") || undefined
     startInNormalMode = config.get<boolean>("startInNormalMode", true)
 }
 /**
@@ -534,9 +549,8 @@ export async function handleKey(key: string, selecting: boolean,
     capture: boolean): Promise<boolean> {
 
     function error() {
-        vscode.window.showWarningMessage("ModalEdit: Undefined key binding: " +
-            keySequence.join(" - "))
-        currentKeymap = null
+        clearKeys()
+        throw new Error(`Undefined key binding: ${keySequence.join(" - ")}`)
     }
 
     if (!currentKeymap) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -105,6 +105,10 @@ let selectStatusColor: string | undefined
  */
 let errorStatusColor: string | undefined
 /**
+ * You can set in the config if you'd like mouse selection to put you in insert mode
+ */
+let mouseSelectionEntersInputMode: boolean
+/**
  * Another thing you can set in config, is whether ModalEdit starts in normal
  * mode. 
  */
@@ -165,6 +169,10 @@ export function getSelectStyles():
 
 export function getErrorStatusColor(): string | undefined {
     return errorStatusColor
+}
+
+export function getMouseSelectionEntersInputMode(): boolean {
+    return mouseSelectionEntersInputMode
 }
 
 export function getStartInNormalMode(): boolean {
@@ -229,6 +237,7 @@ export function updateFromConfig(): void {
     searchStatusColor = config.get("searchStatusColor") || undefined
     selectStatusColor = config.get("selectStatusColor") || undefined
     errorStatusColor = config.get("errorStatusColor") || undefined
+    mouseSelectionEntersInputMode = config.get<boolean>("mouseSelectionEntersInputMode", false)
     startInNormalMode = config.get<boolean>("startInNormalMode", true)
 }
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -471,6 +471,17 @@ export function resetSelecting() {
     selecting = false
 }
 /**
+ * This function gets triggered each time the current editor selections get
+ * updated. If it was a mouse selection and the config mouseSelectionEntersInputMode
+ * is on we enter input mode. We updated the status bar accordingly.
+ */
+export function updateModeOnSelection(isMouseSelection: boolean, editor: vscode.TextEditor) {
+    if (isMouseSelection && actions.getMouseSelectionEntersInputMode()) {
+        enterInsert()
+    }
+    updateCursorAndStatusBar(editor)
+}
+/**
  * ## Search Commands
  *
  * Incremental search is by far the most complicated part of this extension.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
 		channel,
 		vscode.workspace.onDidChangeConfiguration(actions.updateFromConfig),
 		vscode.window.onDidChangeVisibleTextEditors(commands.resetSelecting),
-		vscode.window.onDidChangeTextEditorSelection(e =>
-			commands.updateCursorAndStatusBar(e.textEditor)),
+		vscode.window.onDidChangeTextEditorSelection(e => commands.updateModeOnSelection(e.kind === 2, e.textEditor)),
 		vscode.workspace.onDidChangeTextDocument(commands.onTextChanged))
 	/**
 	 * Next we update the active settings from the config file, and at last, 


### PR DESCRIPTION
I've been going full circle until I found this extension, going from vim emulation to neovim as a backend to finally this.

It's a really cool extension and I'm surprised there's not a lot a ressources on the internet about it.

I'd love to add some minor additions that make sense to me :
 
- Replace the vscode warning message for unmapped keysequences by leveraging the extension's status bar
- Allow the user to have mouse clicks enter input mode (I made this a configurable setting as I know people might disagree with me here, the option is also turned off by default)

As this is my first contribution to this project sorry if I failed to follow previous guidelines.

Please let me know if anything seems weird :smile: